### PR TITLE
Remove '/api/' prefix from core controllers

### DIFF
--- a/Atlas.Api/Controllers/BookingsController.cs
+++ b/Atlas.Api/Controllers/BookingsController.cs
@@ -6,7 +6,8 @@ using Atlas.Api.Models;
 namespace Atlas.Api.Controllers
 {
     [ApiController]
-    [Route("api/bookings")]
+    [Route("bookings")]
+    [Produces("application/json")]
     public class BookingsController : ControllerBase
     {
         private readonly AppDbContext _context;

--- a/Atlas.Api/Controllers/GuestsController.cs
+++ b/Atlas.Api/Controllers/GuestsController.cs
@@ -7,7 +7,8 @@ using Atlas.Api.Models;
 namespace Atlas.Api.Controllers
 {
     [ApiController]
-    [Route("api/guests")]
+    [Route("guests")]
+    [Produces("application/json")]
     public class GuestsController : ControllerBase
     {
         private readonly AppDbContext _context;

--- a/Atlas.Api/Controllers/ListingsController.cs
+++ b/Atlas.Api/Controllers/ListingsController.cs
@@ -7,7 +7,8 @@ using Atlas.Api.Models;
 namespace Atlas.Api.Controllers
 {
     [ApiController]
-    [Route("api/listings")]
+    [Route("listings")]
+    [Produces("application/json")]
     public class ListingsController : ControllerBase
     {
         private readonly AppDbContext _context;

--- a/Atlas.Api/Controllers/PropertiesController.cs
+++ b/Atlas.Api/Controllers/PropertiesController.cs
@@ -7,7 +7,8 @@ using Atlas.Api.Models;
 namespace Atlas.Api.Controllers
 {
     [ApiController]
-    [Route("api/properties")]
+    [Route("properties")]
+    [Produces("application/json")]
     public class PropertiesController : ControllerBase
     {
         private readonly AppDbContext _context;


### PR DESCRIPTION
## Summary
- remove `/api/` prefix from Properties, Listings, Bookings and Guests routes
- mark controllers as producing JSON

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68570749d378832b89752c29bbbf2cc3