### PR TITLE
Allow all CORS origins temporarily

### DIFF
--- a/Atlas.Api/Program.cs
+++ b/Atlas.Api/Program.cs
@@ -15,14 +15,12 @@ namespace Atlas.Api
             // Add services
             builder.Services.AddCors(options =>
             {
-                options.AddDefaultPolicy(policy =>
+                // TODO: Restrict CORS to specific domains after 1 month (e.g., by July 26, 2025)
+                options.AddPolicy("AllowAllOriginsTemp", policy =>
                 {
-                    policy.WithOrigins(
-                        "http://localhost:5173",
-                        "https://admin.atlashomestays.com" // add your production domain here later
-                    )
-                    .AllowAnyHeader()
-                    .AllowAnyMethod();
+                    policy.AllowAnyOrigin()
+                          .AllowAnyHeader()
+                          .AllowAnyMethod();
                 });
             });
             // Add services to the container.
@@ -81,7 +79,7 @@ namespace Atlas.Api
                 app.UseDeveloperExceptionPage(); // Use detailed error page only in development
             }
             app.UseHttpsRedirection();
-            app.UseCors();
+            app.UseCors("AllowAllOriginsTemp");
             app.UseAuthorization();
             app.MapControllers();
             app.Run();


### PR DESCRIPTION
## Summary
- add `AllowAllOriginsTemp` CORS policy with a TODO comment
- apply the policy globally in the middleware pipeline

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c446018b0832b8d9b73e979f62e40