### PR TITLE
Add dev GET endpoint for monthly earnings

### DIFF
--- a/Atlas.Api/Controllers/AdminReportsController.cs
+++ b/Atlas.Api/Controllers/AdminReportsController.cs
@@ -88,6 +88,25 @@ namespace Atlas.Api.Controllers
             return Ok(result);
         }
 
+        [HttpGet("earnings/monthly")]
+        public async Task<ActionResult<IEnumerable<MonthlyEarningsSummary>>> GetMonthlyEarnings()
+        {
+            var query = from p in _context.Payments
+                        join b in _context.Bookings on p.BookingId equals b.Id
+                        select new { p, b };
+
+            var result = await query.GroupBy(x => x.p.ReceivedOn.ToString("yyyy-MM"))
+                .Select(g => new MonthlyEarningsSummary
+                {
+                    Month = g.Key,
+                    TotalGross = g.Sum(x => x.p.Amount),
+                    TotalFees = 0,
+                    TotalNet = g.Sum(x => x.p.Amount)
+                }).ToListAsync();
+
+            return Ok(result);
+        }
+
         [HttpPost("earnings/monthly")]
         public async Task<ActionResult<IEnumerable<MonthlyEarningsSummary>>> GetMonthlyEarnings([FromBody] ReportFilter filter)
         {


### PR DESCRIPTION
## Summary
- expose `GET /admin/reports/earnings/monthly` for dev testing
- implement query to return monthly earnings data

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c55951b04832bb2ab65ce65dc84a3