### PR TITLE
Remove payment status column

### DIFF
--- a/Atlas.Api.Tests/AdminReportsControllerTests.cs
+++ b/Atlas.Api.Tests/AdminReportsControllerTests.cs
@@ -21,9 +21,9 @@ public class AdminReportsControllerTests
         var start = new DateTime(now.Year, now.Month, 1).AddMonths(-11);
 
         context.Bookings.AddRange(
-            new Booking { ListingId = 1, GuestId = 1, CheckinDate = start.AddDays(1), BookingSource = "airbnb", PaymentStatus = "Paid", AmountReceived = 100, Notes = string.Empty },
-            new Booking { ListingId = 1, GuestId = 1, CheckinDate = start.AddMonths(1).AddDays(2), BookingSource = "booking.com", PaymentStatus = "Paid", AmountReceived = 200, Notes = string.Empty },
-            new Booking { ListingId = 1, GuestId = 1, CheckinDate = start.AddMonths(1).AddDays(3), BookingSource = "agoda", PaymentStatus = "Paid", AmountReceived = 300, Notes = string.Empty }
+            new Booking { ListingId = 1, GuestId = 1, CheckinDate = start.AddDays(1), BookingSource = "airbnb", AmountReceived = 100, Notes = string.Empty },
+            new Booking { ListingId = 1, GuestId = 1, CheckinDate = start.AddMonths(1).AddDays(2), BookingSource = "booking.com", AmountReceived = 200, Notes = string.Empty },
+            new Booking { ListingId = 1, GuestId = 1, CheckinDate = start.AddMonths(1).AddDays(3), BookingSource = "agoda", AmountReceived = 300, Notes = string.Empty }
         );
         await context.SaveChangesAsync();
 

--- a/Atlas.Api/Controllers/AdminReportsController.cs
+++ b/Atlas.Api/Controllers/AdminReportsController.cs
@@ -273,7 +273,7 @@ namespace Atlas.Api.Controllers
                 ListingId = b.ListingId,
                 Date = b.CheckinDate,
                 Amount = b.AmountReceived,
-                Status = b.PaymentStatus
+                Status = b.AmountReceived > 0 ? "Paid" : "Unpaid"
             }).ToListAsync();
 
             return Ok(result);

--- a/Atlas.Api/Controllers/BookingsController.cs
+++ b/Atlas.Api/Controllers/BookingsController.cs
@@ -28,6 +28,7 @@ namespace Atlas.Api.Controllers
             try
             {
                 var bookings = await _context.Bookings
+                    .AsNoTracking()
                     .Include(b => b.Listing)
                     .Include(b => b.Guest)
                     .ToListAsync();

--- a/Atlas.Api/Controllers/BookingsController.cs
+++ b/Atlas.Api/Controllers/BookingsController.cs
@@ -90,8 +90,7 @@ namespace Atlas.Api.Controllers
                     AmountGuestPaid = amountGuestPaid,
                     CommissionAmount = commissionAmount,
                     Notes = request.Notes,
-                    CreatedAt = DateTime.UtcNow,
-                    PaymentStatus = request.AmountReceived > 0 ? "Paid" : "Unpaid"
+                    CreatedAt = DateTime.UtcNow
                 };
 
                 _context.Bookings.Add(booking);
@@ -127,7 +126,6 @@ namespace Atlas.Api.Controllers
                 existingBooking.CheckinDate = booking.CheckinDate;
                 existingBooking.CheckoutDate = booking.CheckoutDate;
                 existingBooking.BookingSource = booking.BookingSource;
-                existingBooking.PaymentStatus = booking.PaymentStatus;
                 existingBooking.AmountReceived = booking.AmountReceived;
                 existingBooking.GuestsPlanned = booking.GuestsPlanned;
                 existingBooking.GuestsActual = booking.GuestsActual;

--- a/Atlas.Api/Migrations/20250627130610_RemovePaymentStatusColumn.Designer.cs
+++ b/Atlas.Api/Migrations/20250627130610_RemovePaymentStatusColumn.Designer.cs
@@ -4,6 +4,7 @@ using Atlas.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Atlas.Api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250627130610_RemovePaymentStatusColumn")]
+    partial class RemovePaymentStatusColumn
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Atlas.Api/Migrations/20250627130610_RemovePaymentStatusColumn.cs
+++ b/Atlas.Api/Migrations/20250627130610_RemovePaymentStatusColumn.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Atlas.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemovePaymentStatusColumn : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PaymentStatus",
+                table: "Bookings");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "PaymentStatus",
+                table: "Bookings",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+        }
+    }
+}

--- a/Atlas.Api/Models/Booking.cs
+++ b/Atlas.Api/Models/Booking.cs
@@ -25,7 +25,8 @@ namespace Atlas.Api.Models
         public DateTime CheckinDate { get; set; }
         public DateTime CheckoutDate { get; set; }
         public string BookingSource { get; set; }
-        public string PaymentStatus { get; set; }
+        [NotMapped]
+        public string PaymentStatus => AmountReceived > 0 ? "Paid" : "Unpaid";
         public decimal AmountReceived { get; set; }
         public int GuestsPlanned { get; set; }
         public int GuestsActual { get; set; }


### PR DESCRIPTION
## Summary
- remove manual setting of payment status on Booking
- compute `PaymentStatus` based on `AmountReceived`
- drop `PaymentStatus` column via EF migration
- avoid updating payment status in controller
- adjust reports and unit tests accordingly

## Testing
- `dotnet test Atlas.Api.Tests/Atlas.Api.Tests.csproj`
- `dotnet ef database update --project Atlas.Api --startup-project Atlas.Api` *(fails: A network-related or instance-specific error occurred)*

------
https://chatgpt.com/codex/tasks/task_e_685e95d80384832bada7829986f956a4