### PR TITLE
Add missing booking fields migration

### DIFF
--- a/Atlas.Api/Controllers/BookingsController.cs
+++ b/Atlas.Api/Controllers/BookingsController.cs
@@ -179,11 +179,11 @@ namespace Atlas.Api.Controllers
                 CheckoutDate = booking.CheckoutDate,
                 BookingSource = booking.BookingSource,
                 AmountReceived = booking.AmountReceived,
-                GuestsPlanned = booking.GuestsPlanned,
-                GuestsActual = booking.GuestsActual,
-                ExtraGuestCharge = booking.ExtraGuestCharge,
-                AmountGuestPaid = booking.AmountGuestPaid,
-                CommissionAmount = booking.CommissionAmount,
+                GuestsPlanned = booking.GuestsPlanned ?? 0,
+                GuestsActual = booking.GuestsActual ?? 0,
+                ExtraGuestCharge = booking.ExtraGuestCharge ?? 0,
+                AmountGuestPaid = booking.AmountGuestPaid ?? 0,
+                CommissionAmount = booking.CommissionAmount ?? 0,
                 Notes = booking.Notes,
                 CreatedAt = booking.CreatedAt
             };

--- a/Atlas.Api/Migrations/20250627134609_AddMissingBookingFieldsClean.Designer.cs
+++ b/Atlas.Api/Migrations/20250627134609_AddMissingBookingFieldsClean.Designer.cs
@@ -4,6 +4,7 @@ using Atlas.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Atlas.Api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250627134609_AddMissingBookingFieldsClean")]
+    partial class AddMissingBookingFieldsClean
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Atlas.Api/Migrations/20250627134609_AddMissingBookingFieldsClean.cs
+++ b/Atlas.Api/Migrations/20250627134609_AddMissingBookingFieldsClean.cs
@@ -1,0 +1,132 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Atlas.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMissingBookingFieldsClean : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "GuestsPlanned",
+                table: "Bookings",
+                type: "int",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "int");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "GuestsActual",
+                table: "Bookings",
+                type: "int",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "int");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "ExtraGuestCharge",
+                table: "Bookings",
+                type: "decimal(18,2)",
+                precision: 18,
+                scale: 2,
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "decimal(18,2)",
+                oldPrecision: 18,
+                oldScale: 2);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "CommissionAmount",
+                table: "Bookings",
+                type: "decimal(18,2)",
+                precision: 18,
+                scale: 2,
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "decimal(18,2)",
+                oldPrecision: 18,
+                oldScale: 2);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "AmountGuestPaid",
+                table: "Bookings",
+                type: "decimal(18,2)",
+                precision: 18,
+                scale: 2,
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "decimal(18,2)",
+                oldPrecision: 18,
+                oldScale: 2);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "GuestsPlanned",
+                table: "Bookings",
+                type: "int",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "int",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "GuestsActual",
+                table: "Bookings",
+                type: "int",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "int",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "ExtraGuestCharge",
+                table: "Bookings",
+                type: "decimal(18,2)",
+                precision: 18,
+                scale: 2,
+                nullable: false,
+                defaultValue: 0m,
+                oldClrType: typeof(decimal),
+                oldType: "decimal(18,2)",
+                oldPrecision: 18,
+                oldScale: 2,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "CommissionAmount",
+                table: "Bookings",
+                type: "decimal(18,2)",
+                precision: 18,
+                scale: 2,
+                nullable: false,
+                defaultValue: 0m,
+                oldClrType: typeof(decimal),
+                oldType: "decimal(18,2)",
+                oldPrecision: 18,
+                oldScale: 2,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "AmountGuestPaid",
+                table: "Bookings",
+                type: "decimal(18,2)",
+                precision: 18,
+                scale: 2,
+                nullable: false,
+                defaultValue: 0m,
+                oldClrType: typeof(decimal),
+                oldType: "decimal(18,2)",
+                oldPrecision: 18,
+                oldScale: 2,
+                oldNullable: true);
+        }
+    }
+}

--- a/Atlas.Api/Models/Booking.cs
+++ b/Atlas.Api/Models/Booking.cs
@@ -28,11 +28,11 @@ namespace Atlas.Api.Models
         [NotMapped]
         public string PaymentStatus => AmountReceived > 0 ? "Paid" : "Unpaid";
         public decimal AmountReceived { get; set; }
-        public int GuestsPlanned { get; set; }
-        public int GuestsActual { get; set; }
-        public decimal ExtraGuestCharge { get; set; }
-        public decimal AmountGuestPaid { get; set; }
-        public decimal CommissionAmount { get; set; }
+        public int? GuestsPlanned { get; set; }
+        public int? GuestsActual { get; set; }
+        public decimal? ExtraGuestCharge { get; set; }
+        public decimal? AmountGuestPaid { get; set; }
+        public decimal? CommissionAmount { get; set; }
         public string Notes { get; set; }
 
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;


### PR DESCRIPTION
## Summary
- mark booking guest/commission fields as nullable
- map nullable booking fields to DTO using default values
- add EF Core migration `AddMissingBookingFieldsClean`

## Testing
- `dotnet build Atlas.Api/Atlas.Api.csproj -v minimal`
- `dotnet ef migrations add AddMissingBookingFieldsClean --project Atlas.Api/Atlas.Api.csproj --startup-project Atlas.Api/Atlas.Api.csproj`
- `dotnet ef database update --project Atlas.Api/Atlas.Api.csproj --startup-project Atlas.Api/Atlas.Api.csproj` *(fails: Could not open a connection to SQL Server)*

------
https://chatgpt.com/codex/tasks/task_e_685e9f7bfd70832b8878226a1f76187a