### PR TITLE
Make IdProofUrl optional

### DIFF
--- a/Atlas.Api/Migrations/20250627193623_MakeIdProofUrlNullable.Designer.cs
+++ b/Atlas.Api/Migrations/20250627193623_MakeIdProofUrlNullable.Designer.cs
@@ -4,6 +4,7 @@ using Atlas.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Atlas.Api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250627193623_MakeIdProofUrlNullable")]
+    partial class MakeIdProofUrlNullable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Atlas.Api/Migrations/20250627193623_MakeIdProofUrlNullable.cs
+++ b/Atlas.Api/Migrations/20250627193623_MakeIdProofUrlNullable.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Atlas.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class MakeIdProofUrlNullable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "IdProofUrl",
+                table: "Guests",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "IdProofUrl",
+                table: "Guests",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+        }
+    }
+}

--- a/Atlas.Api/Models/Guest.cs
+++ b/Atlas.Api/Models/Guest.cs
@@ -7,6 +7,6 @@ namespace Atlas.Api.Models
         public string Name { get; set; }
         public string Phone { get; set; }
         public string Email { get; set; }
-        public string IdProofUrl { get; set; }
+        public string? IdProofUrl { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- allow `IdProofUrl` to be nullable
- generate EF migration to update Guests table

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_685ef1960c34832baf4b4b49746e0d63