### PR TITLE
Handle PaymentStatus field

### DIFF
--- a/Atlas.Api/Controllers/BookingsController.cs
+++ b/Atlas.Api/Controllers/BookingsController.cs
@@ -82,6 +82,7 @@ namespace Atlas.Api.Controllers
                     ListingId = request.ListingId,
                     GuestId = request.GuestId,
                     BookingSource = request.BookingSource,
+                    PaymentStatus = string.IsNullOrWhiteSpace(request.PaymentStatus) ? "Pending" : request.PaymentStatus,
                     CheckinDate = request.CheckinDate,
                     CheckoutDate = request.CheckoutDate,
                     AmountReceived = request.AmountReceived,
@@ -185,7 +186,8 @@ namespace Atlas.Api.Controllers
                 AmountGuestPaid = booking.AmountGuestPaid ?? 0,
                 CommissionAmount = booking.CommissionAmount ?? 0,
                 Notes = booking.Notes,
-                CreatedAt = booking.CreatedAt
+                CreatedAt = booking.CreatedAt,
+                PaymentStatus = booking.PaymentStatus
             };
         }
     }

--- a/Atlas.Api/Controllers/GuestsController.cs
+++ b/Atlas.Api/Controllers/GuestsController.cs
@@ -34,6 +34,11 @@ namespace Atlas.Api.Controllers
         [HttpPost]
         public async Task<ActionResult<Guest>> Create(Guest item)
         {
+            if (string.IsNullOrWhiteSpace(item.IdProofUrl))
+            {
+                item.IdProofUrl = "N/A";
+            }
+
             _context.Guests.Add(item);
             await _context.SaveChangesAsync();
             return CreatedAtAction(nameof(Get), new { id = item.Id }, item);

--- a/Atlas.Api/DTOs/BookingDto.cs
+++ b/Atlas.Api/DTOs/BookingDto.cs
@@ -17,6 +17,6 @@ namespace Atlas.Api.DTOs
         public string Notes { get; set; } = string.Empty;
         public DateTime CreatedAt { get; set; }
 
-        public string PaymentStatus => AmountReceived > 0 ? "Paid" : "Unpaid";
+        public string PaymentStatus { get; set; } = "Pending";
     }
 }

--- a/Atlas.Api/DTOs/CreateBookingRequest.cs
+++ b/Atlas.Api/DTOs/CreateBookingRequest.cs
@@ -11,6 +11,7 @@ namespace Atlas.Api.DTOs
         public int GuestsPlanned { get; set; }
         public int GuestsActual { get; set; }
         public decimal ExtraGuestCharge { get; set; }
+        public string? PaymentStatus { get; set; }
         public string Notes { get; set; } = string.Empty;
     }
 }

--- a/Atlas.Api/Migrations/20250627211516_AddPaymentStatusToBooking.Designer.cs
+++ b/Atlas.Api/Migrations/20250627211516_AddPaymentStatusToBooking.Designer.cs
@@ -4,6 +4,7 @@ using Atlas.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Atlas.Api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250627211516_AddPaymentStatusToBooking")]
+    partial class AddPaymentStatusToBooking
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Atlas.Api/Migrations/20250627211516_AddPaymentStatusToBooking.cs
+++ b/Atlas.Api/Migrations/20250627211516_AddPaymentStatusToBooking.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Atlas.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPaymentStatusToBooking : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "PaymentStatus",
+                table: "Bookings",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "Pending");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PaymentStatus",
+                table: "Bookings");
+        }
+    }
+}

--- a/Atlas.Api/Models/Booking.cs
+++ b/Atlas.Api/Models/Booking.cs
@@ -25,8 +25,7 @@ namespace Atlas.Api.Models
         public DateTime CheckinDate { get; set; }
         public DateTime CheckoutDate { get; set; }
         public string BookingSource { get; set; }
-        [NotMapped]
-        public string PaymentStatus => AmountReceived > 0 ? "Paid" : "Unpaid";
+        public string PaymentStatus { get; set; } = "Pending";
         public decimal AmountReceived { get; set; }
         public int? GuestsPlanned { get; set; }
         public int? GuestsActual { get; set; }


### PR DESCRIPTION
## Summary
- default `PaymentStatus` to "Pending" when creating bookings
- reintroduce `PaymentStatus` on Booking model and DTO
- update `CreateBookingRequest` to accept optional `PaymentStatus`
- EF Core migration adds `PaymentStatus` column with default value

## Testing
- `dotnet test AtlasHomestays.sln`
- `dotnet ef database update` *(fails: could not open connection)*

------
https://chatgpt.com/codex/tasks/task_e_685f04ce3510832b869ebfa581ad19d1