### PR TITLE
Add bank account entity and CRUD + link booking

### DIFF
--- a/Atlas.Api/Controllers/BankAccountsController.cs
+++ b/Atlas.Api/Controllers/BankAccountsController.cs
@@ -1,0 +1,90 @@
+using Atlas.Api.Data;
+using Atlas.Api.DTOs;
+using Atlas.Api.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace Atlas.Api.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class BankAccountsController : ControllerBase
+    {
+        private readonly AppDbContext _context;
+        private readonly ILogger<BankAccountsController> _logger;
+
+        public BankAccountsController(AppDbContext context, ILogger<BankAccountsController> logger)
+        {
+            _context = context;
+            _logger = logger;
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<BankAccountResponseDto>>> GetAll()
+        {
+            var accounts = await _context.BankAccounts.AsNoTracking().ToListAsync();
+            return accounts.Select(MapToDto).ToList();
+        }
+
+        [HttpGet("{id}")]
+        public async Task<ActionResult<BankAccountResponseDto>> Get(int id)
+        {
+            var account = await _context.BankAccounts.FindAsync(id);
+            return account == null ? NotFound() : MapToDto(account);
+        }
+
+        [HttpPost]
+        public async Task<ActionResult<BankAccountResponseDto>> Create(BankAccountRequestDto request)
+        {
+            var account = new BankAccount
+            {
+                BankName = request.BankName,
+                AccountNumber = request.AccountNumber,
+                IFSC = request.IFSC,
+                AccountType = request.AccountType,
+                CreatedAt = DateTime.UtcNow
+            };
+            _context.BankAccounts.Add(account);
+            await _context.SaveChangesAsync();
+            return CreatedAtAction(nameof(Get), new { id = account.Id }, MapToDto(account));
+        }
+
+        [HttpPut("{id}")]
+        public async Task<IActionResult> Update(int id, BankAccountRequestDto request)
+        {
+            var account = await _context.BankAccounts.FindAsync(id);
+            if (account == null) return NotFound();
+
+            account.BankName = request.BankName;
+            account.AccountNumber = request.AccountNumber;
+            account.IFSC = request.IFSC;
+            account.AccountType = request.AccountType;
+
+            await _context.SaveChangesAsync();
+            return NoContent();
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(int id)
+        {
+            var account = await _context.BankAccounts.FindAsync(id);
+            if (account == null) return NotFound();
+            _context.BankAccounts.Remove(account);
+            await _context.SaveChangesAsync();
+            return NoContent();
+        }
+
+        private static BankAccountResponseDto MapToDto(BankAccount account)
+        {
+            return new BankAccountResponseDto
+            {
+                Id = account.Id,
+                BankName = account.BankName,
+                AccountNumber = account.AccountNumber,
+                IFSC = account.IFSC,
+                AccountType = account.AccountType,
+                CreatedAt = account.CreatedAt
+            };
+        }
+    }
+}

--- a/Atlas.Api/Controllers/BookingsController.cs
+++ b/Atlas.Api/Controllers/BookingsController.cs
@@ -86,6 +86,7 @@ namespace Atlas.Api.Controllers
                     CheckinDate = request.CheckinDate,
                     CheckoutDate = request.CheckoutDate,
                     AmountReceived = request.AmountReceived,
+                    BankAccountId = request.BankAccountId,
                     GuestsPlanned = request.GuestsPlanned,
                     GuestsActual = request.GuestsActual,
                     ExtraGuestCharge = request.ExtraGuestCharge,
@@ -135,6 +136,7 @@ namespace Atlas.Api.Controllers
                 existingBooking.AmountGuestPaid = booking.AmountGuestPaid;
                 existingBooking.CommissionAmount = booking.CommissionAmount;
                 existingBooking.Notes = booking.Notes;
+                existingBooking.BankAccountId = booking.BankAccountId;
 
                 await _context.SaveChangesAsync();
                 return NoContent();
@@ -180,6 +182,7 @@ namespace Atlas.Api.Controllers
                 CheckoutDate = booking.CheckoutDate,
                 BookingSource = booking.BookingSource,
                 AmountReceived = booking.AmountReceived,
+                BankAccountId = booking.BankAccountId,
                 GuestsPlanned = booking.GuestsPlanned ?? 0,
                 GuestsActual = booking.GuestsActual ?? 0,
                 ExtraGuestCharge = booking.ExtraGuestCharge ?? 0,

--- a/Atlas.Api/DTOs/BankAccountRequestDto.cs
+++ b/Atlas.Api/DTOs/BankAccountRequestDto.cs
@@ -1,0 +1,10 @@
+namespace Atlas.Api.DTOs
+{
+    public class BankAccountRequestDto
+    {
+        public string BankName { get; set; } = string.Empty;
+        public string AccountNumber { get; set; } = string.Empty;
+        public string IFSC { get; set; } = string.Empty;
+        public string AccountType { get; set; } = string.Empty;
+    }
+}

--- a/Atlas.Api/DTOs/BankAccountResponseDto.cs
+++ b/Atlas.Api/DTOs/BankAccountResponseDto.cs
@@ -1,0 +1,12 @@
+namespace Atlas.Api.DTOs
+{
+    public class BankAccountResponseDto
+    {
+        public int Id { get; set; }
+        public string BankName { get; set; } = string.Empty;
+        public string AccountNumber { get; set; } = string.Empty;
+        public string IFSC { get; set; } = string.Empty;
+        public string AccountType { get; set; } = string.Empty;
+        public DateTime CreatedAt { get; set; }
+    }
+}

--- a/Atlas.Api/DTOs/BookingDto.cs
+++ b/Atlas.Api/DTOs/BookingDto.cs
@@ -9,6 +9,7 @@ namespace Atlas.Api.DTOs
         public DateTime CheckoutDate { get; set; }
         public string BookingSource { get; set; } = string.Empty;
         public decimal AmountReceived { get; set; }
+        public int? BankAccountId { get; set; }
         public int GuestsPlanned { get; set; }
         public int GuestsActual { get; set; }
         public decimal ExtraGuestCharge { get; set; }

--- a/Atlas.Api/DTOs/CreateBookingRequest.cs
+++ b/Atlas.Api/DTOs/CreateBookingRequest.cs
@@ -8,6 +8,7 @@ namespace Atlas.Api.DTOs
         public DateTime CheckoutDate { get; set; }
         public string BookingSource { get; set; } = string.Empty;
         public decimal AmountReceived { get; set; }
+        public int? BankAccountId { get; set; }
         public int GuestsPlanned { get; set; }
         public int GuestsActual { get; set; }
         public decimal ExtraGuestCharge { get; set; }

--- a/Atlas.Api/Data/AppDbContext.cs
+++ b/Atlas.Api/Data/AppDbContext.cs
@@ -41,5 +41,6 @@ namespace Atlas.Api.Data
         public DbSet<Incident> Incidents { get; set; }
         public DbSet<User> Users { get; set; }
         public DbSet<Payment> Payments { get; set; }
+        public DbSet<BankAccount> BankAccounts { get; set; }
     }
 }

--- a/Atlas.Api/Migrations/20250629065711_AddBankAccountAndLinkToBookings.Designer.cs
+++ b/Atlas.Api/Migrations/20250629065711_AddBankAccountAndLinkToBookings.Designer.cs
@@ -4,6 +4,7 @@ using Atlas.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Atlas.Api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250629065711_AddBankAccountAndLinkToBookings")]
+    partial class AddBankAccountAndLinkToBookings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Atlas.Api/Migrations/20250629065711_AddBankAccountAndLinkToBookings.cs
+++ b/Atlas.Api/Migrations/20250629065711_AddBankAccountAndLinkToBookings.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Atlas.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddBankAccountAndLinkToBookings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "BankAccountId",
+                table: "Bookings",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "BankAccounts",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    BankName = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    AccountNumber = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    IFSC = table.Column<string>(type: "nvarchar(20)", maxLength: 20, nullable: false),
+                    AccountType = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_BankAccounts", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Bookings_BankAccountId",
+                table: "Bookings",
+                column: "BankAccountId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Bookings_BankAccounts_BankAccountId",
+                table: "Bookings",
+                column: "BankAccountId",
+                principalTable: "BankAccounts",
+                principalColumn: "Id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Bookings_BankAccounts_BankAccountId",
+                table: "Bookings");
+
+            migrationBuilder.DropTable(
+                name: "BankAccounts");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Bookings_BankAccountId",
+                table: "Bookings");
+
+            migrationBuilder.DropColumn(
+                name: "BankAccountId",
+                table: "Bookings");
+        }
+    }
+}

--- a/Atlas.Api/Models/BankAccount.cs
+++ b/Atlas.Api/Models/BankAccount.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Atlas.Api.Models
+{
+    public class BankAccount
+    {
+        public int Id { get; set; }
+
+        [MaxLength(100)]
+        public string BankName { get; set; } = string.Empty;
+
+        [MaxLength(50)]
+        public string AccountNumber { get; set; } = string.Empty;
+
+        [MaxLength(20)]
+        public string IFSC { get; set; } = string.Empty;
+
+        [MaxLength(50)]
+        public string AccountType { get; set; } = string.Empty;
+
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    }
+}

--- a/Atlas.Api/Models/Booking.cs
+++ b/Atlas.Api/Models/Booking.cs
@@ -27,6 +27,11 @@ namespace Atlas.Api.Models
         public string BookingSource { get; set; }
         public string PaymentStatus { get; set; } = "Pending";
         public decimal AmountReceived { get; set; }
+        [ForeignKey(nameof(BankAccount))]
+        public int? BankAccountId { get; set; }
+
+        [JsonIgnore]
+        public BankAccount? BankAccount { get; set; }
         public int? GuestsPlanned { get; set; }
         public int? GuestsActual { get; set; }
         public decimal? ExtraGuestCharge { get; set; }


### PR DESCRIPTION
## Summary
- create `BankAccount` entity and DbSet
- link bookings to bank accounts
- generate EF migration to add table and FK
- add DTOs and controller for bank accounts
- allow bookings to accept BankAccountId

## Testing
- `dotnet build`
- `dotnet ef migrations add AddBankAccountAndLinkToBookings` *(passed)*
- `dotnet ef database update` *(failed: cannot connect to SQL Server)*

------
https://chatgpt.com/codex/tasks/task_e_6860e2e4c828832b9109efbfabf18619