### PR TITLE
Fix test framework and logger signature

### DIFF
--- a/Atlas.Api.IntegrationTests/Atlas.Api.IntegrationTests.csproj
+++ b/Atlas.Api.IntegrationTests/Atlas.Api.IntegrationTests.csproj
@@ -1,16 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.22" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.22" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.5" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../Atlas.Api/Atlas.Api.csproj" />

--- a/Atlas.Api.IntegrationTests/GlobalUsings.cs
+++ b/Atlas.Api.IntegrationTests/GlobalUsings.cs
@@ -1,3 +1,3 @@
 global using System.Net.Http.Json;
-using Xunit;
+global using Xunit;
 

--- a/Atlas.Api.Tests/BookingsControllerTests.cs
+++ b/Atlas.Api.Tests/BookingsControllerTests.cs
@@ -109,8 +109,8 @@ public class BookingsControllerTests
             Microsoft.Extensions.Logging.LogLevel.Error,
             Moq.It.IsAny<Microsoft.Extensions.Logging.EventId>(),
             Moq.It.IsAny<Moq.It.IsAnyType>(),
-            Moq.It.IsAny<DbUpdateConcurrencyException>(),
-            (Func<Moq.It.IsAnyType, Exception, string>)Moq.It.IsAny<object>()),
+            Moq.It.IsAny<DbUpdateConcurrencyException?>(),
+            (Func<Moq.It.IsAnyType, Exception?, string>)Moq.It.IsAny<object>()),
             Moq.Times.Once);
     }
 


### PR DESCRIPTION
## Summary
- target integration tests project to .NET 8
- enable implicit usings for integration tests and reference 8/9.x packages
- fix BookingsController tests to use nullable `ILogger.Log` signature

## Testing
- `dotnet build AtlasHomestays.sln`

------
https://chatgpt.com/codex/tasks/task_e_68637941d16c832b81e2bfb87cbee8ab