### PR TITLE
Support filtering bookings by check‑in dates

### DIFF
--- a/Atlas.Api/Controllers/BookingsController.cs
+++ b/Atlas.Api/Controllers/BookingsController.cs
@@ -31,18 +31,37 @@ namespace Atlas.Api.Controllers
             {
                 var query = _context.Bookings
                     .AsNoTracking()
-                    .Include(b => b.Listing)
-                    .Include(b => b.Guest)
                     .AsQueryable();
 
-                if (checkinStart.HasValue && checkinEnd.HasValue)
-                {
-                    query = query.Where(b => b.CheckinDate >= checkinStart.Value && b.CheckinDate <= checkinEnd.Value);
-                }
+                if (checkinStart.HasValue)
+                    query = query.Where(b => b.CheckinDate >= checkinStart.Value);
 
-                var bookings = await query.ToListAsync();
-                var result = bookings.Select(MapToDto).ToList();
-                return Ok(result);
+                if (checkinEnd.HasValue)
+                    query = query.Where(b => b.CheckinDate <= checkinEnd.Value);
+
+                var bookings = await query
+                    .Select(b => new BookingDto
+                    {
+                        Id = b.Id,
+                        ListingId = b.ListingId,
+                        GuestId = b.GuestId,
+                        CheckinDate = b.CheckinDate,
+                        CheckoutDate = b.CheckoutDate,
+                        BookingSource = b.BookingSource,
+                        AmountReceived = b.AmountReceived,
+                        BankAccountId = b.BankAccountId,
+                        GuestsPlanned = b.GuestsPlanned ?? 0,
+                        GuestsActual = b.GuestsActual ?? 0,
+                        ExtraGuestCharge = b.ExtraGuestCharge ?? 0,
+                        AmountGuestPaid = b.AmountGuestPaid ?? 0,
+                        CommissionAmount = b.CommissionAmount ?? 0,
+                        Notes = b.Notes,
+                        CreatedAt = b.CreatedAt,
+                        PaymentStatus = b.PaymentStatus
+                    })
+                    .ToListAsync();
+
+                return Ok(bookings);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary
- accept `checkinStart`/`checkinEnd` query params on GET /bookings
- filter bookings by these parameters
- project results to `BookingDto` inside the query

## Testing
- ❌ `dotnet test` *(fails: `dotnet` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688529f50224832bb8585a9f29fa0744