### PR TITLE
Fix GitHub Actions publish path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,8 +24,8 @@ jobs:
       - name: Build
         run: dotnet build --configuration Release --no-restore
 
-      - name: Publish
-        run: dotnet publish --configuration Release --output ./publish
+      - name: Publish .NET API
+        run: dotnet publish ./Atlas.Api/Atlas.Api.csproj -c Release -o ./publish
 
       - name: Deploy to Azure Web App
         uses: azure/webapps-deploy@v2


### PR DESCRIPTION
## Summary
- fix .NET publish path in GitHub Actions workflow to only publish Atlas.Api

## Testing
- `dotnet test` *(fails: unable to connect to the database)*

------
https://chatgpt.com/codex/tasks/task_e_6885302a24c0832b877d3b94e0e9054c