### PR TITLE
Add AdminReportsController GET tests

### DIFF
--- a/Atlas.Api.Tests/AdminReportsControllerTests.cs
+++ b/Atlas.Api.Tests/AdminReportsControllerTests.cs
@@ -94,4 +94,123 @@ public class AdminReportsControllerTests
         Assert.Equal(2, a.Count);
         Assert.Equal(40, a.TotalAmount);
     }
+
+    [Fact]
+    public async Task GetBookings_ReturnsAll_WhenNoFilters()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(nameof(GetBookings_ReturnsAll_WhenNoFilters))
+            .Options;
+        using var context = new AppDbContext(options);
+        context.Bookings.AddRange(
+            new Booking { Id = 1, ListingId = 1, GuestId = 1, CheckinDate = DateTime.UtcNow.AddDays(-1), CheckoutDate = DateTime.UtcNow, BookingSource = "a", AmountReceived = 1, Notes = "n", PaymentStatus = "Pending" },
+            new Booking { Id = 2, ListingId = 2, GuestId = 1, CheckinDate = DateTime.UtcNow.AddDays(-2), CheckoutDate = DateTime.UtcNow, BookingSource = "b", AmountReceived = 1, Notes = "n", PaymentStatus = "Pending" }
+        );
+        await context.SaveChangesAsync();
+        var controller = new AdminReportsController(context, NullLogger<AdminReportsController>.Instance);
+
+        var result = await controller.GetBookings(null, null, null);
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var list = Assert.IsAssignableFrom<IEnumerable<BookingInfo>>(ok.Value);
+        Assert.Equal(2, list.Count());
+    }
+
+    [Fact]
+    public async Task GetListings_ReturnsAll_WithStatusFlag()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(nameof(GetListings_ReturnsAll_WithStatusFlag))
+            .Options;
+        using var context = new AppDbContext(options);
+        var property = new Property { Id = 1, Name = "p", Address = "a", Type = "t", OwnerName = "o", ContactPhone = "c", Status = "s" };
+        context.Properties.Add(property);
+        context.Listings.AddRange(
+            new Listing { Id = 1, Property = property, PropertyId = 1, Name = "L1", Floor = 1, Type = "T", Status = "Active", WifiName = "w", WifiPassword = "p", MaxGuests = 2 },
+            new Listing { Id = 2, Property = property, PropertyId = 1, Name = "L2", Floor = 1, Type = "T", Status = "Inactive", WifiName = "w", WifiPassword = "p", MaxGuests = 2 }
+        );
+        await context.SaveChangesAsync();
+        var controller = new AdminReportsController(context, NullLogger<AdminReportsController>.Instance);
+
+        var result = await controller.GetListings();
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var list = Assert.IsAssignableFrom<IEnumerable<ListingInfo>>(ok.Value).ToList();
+        Assert.Equal(2, list.Count);
+        Assert.True(list.Single(l => l.ListingId == 1).IsActive);
+        Assert.False(list.Single(l => l.ListingId == 2).IsActive);
+    }
+
+    [Fact]
+    public async Task GetPayouts_ReturnsGroupedTotals()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(nameof(GetPayouts_ReturnsGroupedTotals))
+            .Options;
+        using var context = new AppDbContext(options);
+        context.Bookings.Add(new Booking { Id = 1, ListingId = 1, GuestId = 1, CheckinDate = DateTime.UtcNow, CheckoutDate = DateTime.UtcNow, BookingSource = "a", AmountReceived = 1, Notes = "n", PaymentStatus = "Pending" });
+        context.Payments.AddRange(
+            new Payment { BookingId = 1, Amount = 50, Method = "cash", Type = "pay", ReceivedOn = DateTime.UtcNow, Note = "n" },
+            new Payment { BookingId = 1, Amount = 75, Method = "cash", Type = "pay", ReceivedOn = DateTime.UtcNow, Note = "n" }
+        );
+        await context.SaveChangesAsync();
+        var controller = new AdminReportsController(context, NullLogger<AdminReportsController>.Instance);
+
+        var result = await controller.GetPayouts(null, null, null);
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var list = Assert.IsAssignableFrom<IEnumerable<DailyPayout>>(ok.Value).ToList();
+        Assert.Single(list);
+        Assert.Equal(125, list[0].Amount);
+    }
+
+    [Fact]
+    public async Task GetDailyPayoutReport_FiltersByListing()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(nameof(GetDailyPayoutReport_FiltersByListing))
+            .Options;
+        using var context = new AppDbContext(options);
+        var property = new Property { Id = 1, Name = "p", Address = "a", Type = "t", OwnerName = "o", ContactPhone = "c", Status = "s" };
+        context.Properties.Add(property);
+        var listing1 = new Listing { Id = 1, Property = property, PropertyId = 1, Name = "L1", Floor = 1, Type = "T", Status = "Active", WifiName = "w", WifiPassword = "p", MaxGuests = 2 };
+        var listing2 = new Listing { Id = 2, Property = property, PropertyId = 1, Name = "L2", Floor = 1, Type = "T", Status = "Active", WifiName = "w", WifiPassword = "p", MaxGuests = 2 };
+        context.Listings.AddRange(listing1, listing2);
+        context.Bookings.AddRange(
+            new Booking { Id = 1, ListingId = 1, Listing = listing1, GuestId = 1, CheckinDate = DateTime.UtcNow, CheckoutDate = DateTime.UtcNow, BookingSource = "a", AmountReceived = 1, Notes = "n", PaymentStatus = "Pending" },
+            new Booking { Id = 2, ListingId = 2, Listing = listing2, GuestId = 1, CheckinDate = DateTime.UtcNow, CheckoutDate = DateTime.UtcNow, BookingSource = "a", AmountReceived = 2, Notes = "n", PaymentStatus = "Pending" }
+        );
+        context.Payments.AddRange(
+            new Payment { BookingId = 1, Amount = 50, Method = "cash", Type = "pay", ReceivedOn = DateTime.UtcNow.Date, Note = "n" },
+            new Payment { BookingId = 2, Amount = 70, Method = "cash", Type = "pay", ReceivedOn = DateTime.UtcNow.Date, Note = "n" }
+        );
+        await context.SaveChangesAsync();
+        var controller = new AdminReportsController(context, NullLogger<AdminReportsController>.Instance);
+
+        var result = await controller.GetDailyPayoutReport(null, null, new List<int> { 1 });
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var list = Assert.IsAssignableFrom<IEnumerable<DailyPayout>>(ok.Value).ToList();
+        Assert.Single(list);
+        Assert.Equal(50, list[0].Amount);
+        Assert.Equal("L1", list[0].Listing);
+    }
+
+    [Fact]
+    public async Task GetCalendarBookings_ReturnsDataForListing()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(nameof(GetCalendarBookings_ReturnsDataForListing))
+            .Options;
+        using var context = new AppDbContext(options);
+        context.Bookings.AddRange(
+            new Booking { Id = 1, ListingId = 1, GuestId = 1, CheckinDate = DateTime.UtcNow.Date, CheckoutDate = DateTime.UtcNow.Date.AddDays(1), BookingSource = "a", AmountReceived = 10, Notes = "n", PaymentStatus = "Pending" },
+            new Booking { Id = 2, ListingId = 1, GuestId = 1, CheckinDate = DateTime.UtcNow.Date.AddDays(1), CheckoutDate = DateTime.UtcNow.Date.AddDays(2), BookingSource = "a", AmountReceived = 0, Notes = "n", PaymentStatus = "Pending" }
+        );
+        await context.SaveChangesAsync();
+        var controller = new AdminReportsController(context, NullLogger<AdminReportsController>.Instance);
+
+        var result = await controller.GetCalendarBookings(null, null, new List<int> { 1 });
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var list = Assert.IsAssignableFrom<IEnumerable<CalendarBooking>>(ok.Value).ToList();
+        Assert.Equal(2, list.Count);
+        Assert.Equal("Paid", list[0].Status);
+        Assert.Equal("Unpaid", list[1].Status);
+    }
 }


### PR DESCRIPTION
## Summary
- increase test coverage for AdminReportsController
- cover edge cases for missing date ranges and listing report details

## Testing
- `dotnet test Atlas.Api.Tests`

------
https://chatgpt.com/codex/tasks/task_e_68853cb4ca24832bab40a3f99592f2ef