### PR TITLE
Fix integration tests and booking relationships

### DIFF
--- a/Atlas.Api.IntegrationTests/BookingsApiTests.cs
+++ b/Atlas.Api.IntegrationTests/BookingsApiTests.cs
@@ -47,6 +47,7 @@ public class BookingsApiTests : IntegrationTestBase
         await db.SaveChangesAsync();
         var booking = new Booking
         {
+            PropertyId = property.Id,
             ListingId = listing.Id,
             GuestId = guest.Id,
             BookingSource = "airbnb",
@@ -87,6 +88,7 @@ public class BookingsApiTests : IntegrationTestBase
 
         var newBooking = new Booking
         {
+            PropertyId = data.property.Id,
             ListingId = data.listing.Id,
             GuestId = data.guest.Id,
             BookingSource = "airbnb",

--- a/Atlas.Api/Data/AppDbContext.cs
+++ b/Atlas.Api/Data/AppDbContext.cs
@@ -32,6 +32,24 @@ namespace Atlas.Api.Data
             modelBuilder.Entity<Property>()
                 .Property(p => p.CommissionPercent)
                 .HasPrecision(5, 2);
+
+            modelBuilder.Entity<Booking>()
+                .HasOne(b => b.Guest)
+                .WithMany()
+                .HasForeignKey(b => b.GuestId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            modelBuilder.Entity<Booking>()
+                .HasOne(b => b.Listing)
+                .WithMany(l => l.Bookings)
+                .HasForeignKey(b => b.ListingId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            modelBuilder.Entity<Booking>()
+                .HasOne(b => b.Property)
+                .WithMany()
+                .HasForeignKey(b => b.PropertyId)
+                .OnDelete(DeleteBehavior.Cascade);
         }
 
         public DbSet<Property> Properties { get; set; }

--- a/Atlas.Api/Migrations/20250726211328_AddPropertyToBooking.Designer.cs
+++ b/Atlas.Api/Migrations/20250726211328_AddPropertyToBooking.Designer.cs
@@ -4,6 +4,7 @@ using Atlas.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Atlas.Api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250726211328_AddPropertyToBooking")]
+    partial class AddPropertyToBooking
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Atlas.Api/Migrations/20250726211328_AddPropertyToBooking.cs
+++ b/Atlas.Api/Migrations/20250726211328_AddPropertyToBooking.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Atlas.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPropertyToBooking : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "PropertyId",
+                table: "Bookings",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Bookings_PropertyId",
+                table: "Bookings",
+                column: "PropertyId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Bookings_Properties_PropertyId",
+                table: "Bookings",
+                column: "PropertyId",
+                principalTable: "Properties",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Bookings_Properties_PropertyId",
+                table: "Bookings");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Bookings_PropertyId",
+                table: "Bookings");
+
+            migrationBuilder.DropColumn(
+                name: "PropertyId",
+                table: "Bookings");
+        }
+    }
+}

--- a/Atlas.Api/Models/Booking.cs
+++ b/Atlas.Api/Models/Booking.cs
@@ -16,6 +16,13 @@ namespace Atlas.Api.Models
         public Listing? Listing { get; set; }
 
         [Required]
+        [ForeignKey(nameof(Property))]
+        public int PropertyId { get; set; }
+
+        [JsonIgnore]
+        public Property? Property { get; set; }
+
+        [Required]
         [ForeignKey(nameof(Guest))]
         public int GuestId { get; set; }
 


### PR DESCRIPTION
## Summary
- add Property navigation to `Booking` and configure relationships in `AppDbContext`
- add migration for new `PropertyId` column on `Bookings`
- seed complete property/listing/guest/booking data for tests
- update booking tests to provide `PropertyId`

## Testing
- `dotnet build AtlasHomestays.sln -c Release`
- `dotnet test Atlas.Api.IntegrationTests/Atlas.Api.IntegrationTests.csproj -c Release --no-build` *(fails: LocalDB not supported)*

------
https://chatgpt.com/codex/tasks/task_e_688543a19bd0832baefadc3d1222647e