### PR TITLE
Add payment status validation tests

### DIFF
--- a/Atlas.Api.IntegrationTests/BookingsApiTests.cs
+++ b/Atlas.Api.IntegrationTests/BookingsApiTests.cs
@@ -148,6 +148,90 @@ public class BookingsApiTests : IntegrationTestBase
     }
 
     [Fact]
+    public async Task Post_ReturnsBadRequest_WhenPaymentStatusMissing()
+    {
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var data = await SeedBookingAsync(db);
+
+        var request = new
+        {
+            ListingId = data.listing.Id,
+            GuestId = data.guest.Id,
+            BookingSource = "airbnb",
+            CheckinDate = DateTime.UtcNow.Date,
+            CheckoutDate = DateTime.UtcNow.Date.AddDays(2),
+            AmountReceived = 200,
+            GuestsPlanned = 2,
+            GuestsActual = 2,
+            ExtraGuestCharge = 0,
+            Notes = "create"
+        };
+
+        var response = await Client.PostAsJsonAsync("/api/bookings", request);
+
+        Assert.Equal(System.Net.HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Put_ReturnsBadRequest_WhenPaymentStatusMissing()
+    {
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var data = await SeedBookingAsync(db);
+
+        var request = new
+        {
+            Id = data.booking.Id,
+            ListingId = data.booking.ListingId,
+            PropertyId = data.booking.PropertyId,
+            GuestId = data.booking.GuestId,
+            BookingSource = data.booking.BookingSource,
+            CheckinDate = data.booking.CheckinDate,
+            CheckoutDate = data.booking.CheckoutDate,
+            AmountReceived = data.booking.AmountReceived,
+            GuestsPlanned = data.booking.GuestsPlanned,
+            GuestsActual = data.booking.GuestsActual,
+            ExtraGuestCharge = data.booking.ExtraGuestCharge,
+            AmountGuestPaid = data.booking.AmountGuestPaid,
+            CommissionAmount = data.booking.CommissionAmount,
+            Notes = "updated",
+            BankAccountId = data.booking.BankAccountId
+        };
+
+        var response = await Client.PutAsJsonAsync($"/api/bookings/{data.booking.Id}", request);
+
+        Assert.Equal(System.Net.HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_ReturnsCreated_WhenPaymentStatusProvided()
+    {
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var data = await SeedBookingAsync(db);
+
+        var request = new
+        {
+            ListingId = data.listing.Id,
+            GuestId = data.guest.Id,
+            BookingSource = "airbnb",
+            PaymentStatus = "Paid",
+            CheckinDate = DateTime.UtcNow.Date,
+            CheckoutDate = DateTime.UtcNow.Date.AddDays(3),
+            AmountReceived = 250,
+            GuestsPlanned = 2,
+            GuestsActual = 2,
+            ExtraGuestCharge = 0,
+            Notes = "full"
+        };
+
+        var response = await Client.PostAsJsonAsync("/api/bookings", request);
+
+        Assert.Equal(System.Net.HttpStatusCode.Created, response.StatusCode);
+    }
+
+    [Fact]
     public async Task Delete_RemovesBooking()
     {
         using var scope = Factory.Services.CreateScope();

--- a/Atlas.Api.Tests/BookingsControllerTests.cs
+++ b/Atlas.Api.Tests/BookingsControllerTests.cs
@@ -74,6 +74,24 @@ public class BookingsControllerTests
     }
 
     [Fact]
+    public async Task Update_ReturnsBadRequest_WhenPaymentStatusMissing()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(databaseName: nameof(Update_ReturnsBadRequest_WhenPaymentStatusMissing))
+            .Options;
+        using var context = new AppDbContext(options);
+        context.Bookings.Add(new Booking { Id = 1, ListingId = 1, GuestId = 1, BookingSource = "a", Notes = "n", PaymentStatus = "Pending" });
+        await context.SaveChangesAsync();
+        var controller = new BookingsController(context, NullLogger<BookingsController>.Instance);
+        controller.ModelState.AddModelError("paymentStatus", "The PaymentStatus field is required.");
+        var booking = new Booking { Id = 1, ListingId = 1, GuestId = 1, BookingSource = "a", Notes = "n", PaymentStatus = null! };
+
+        var result = await controller.Update(1, booking);
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
     public async Task Delete_ReturnsNotFound_WhenMissing()
     {
         var options = new DbContextOptionsBuilder<AppDbContext>()

--- a/Atlas.Api/Controllers/BookingsController.cs
+++ b/Atlas.Api/Controllers/BookingsController.cs
@@ -156,6 +156,10 @@ namespace Atlas.Api.Controllers
                 existingBooking.CheckinDate = booking.CheckinDate;
                 existingBooking.CheckoutDate = booking.CheckoutDate;
                 existingBooking.BookingSource = booking.BookingSource;
+                if (!string.IsNullOrWhiteSpace(booking.PaymentStatus))
+                {
+                    existingBooking.PaymentStatus = booking.PaymentStatus;
+                }
                 existingBooking.AmountReceived = booking.AmountReceived;
                 existingBooking.GuestsPlanned = booking.GuestsPlanned;
                 existingBooking.GuestsActual = booking.GuestsActual;


### PR DESCRIPTION
## Summary
- update booking update endpoint to persist payment status
- add integration tests for missing paymentStatus
- add unit test for missing paymentStatus

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68878530d530832b94b3ff90f492fb79