### PR TITLE
Fix listing-booking relation and migration

### DIFF
--- a/Atlas.Api/Data/AppDbContext.cs
+++ b/Atlas.Api/Data/AppDbContext.cs
@@ -41,8 +41,9 @@ namespace Atlas.Api.Data
 
             modelBuilder.Entity<Booking>()
                 .HasOne(b => b.Listing)
-                .WithMany()
-                .HasForeignKey(b => b.ListingId);
+                .WithMany(l => l.Bookings)
+                .HasForeignKey(b => b.ListingId)
+                .OnDelete(DeleteBehavior.Restrict);
 
             modelBuilder.Entity<Booking>()
                 .HasOne(b => b.Property)

--- a/Atlas.Api/Migrations/20250728160020_FixListingBookingNavigation.Designer.cs
+++ b/Atlas.Api/Migrations/20250728160020_FixListingBookingNavigation.Designer.cs
@@ -4,6 +4,7 @@ using Atlas.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Atlas.Api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250728160020_FixListingBookingNavigation")]
+    partial class FixListingBookingNavigation
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -372,9 +375,9 @@ namespace Atlas.Api.Migrations
                         .IsRequired();
 
                     b.HasOne("Atlas.Api.Models.Listing", "Listing")
-                        .WithMany()
+                        .WithMany("Bookings")
                         .HasForeignKey("ListingId")
-                        .OnDelete(DeleteBehavior.Cascade)
+                        .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
                     b.HasOne("Atlas.Api.Models.Property", "Property")
@@ -384,6 +387,10 @@ namespace Atlas.Api.Migrations
                         .IsRequired();
 
                     b.Navigation("BankAccount");
+
+                    b.Navigation("Guest");
+
+                    b.Navigation("Listing");
 
                     b.Navigation("Property");
                 });
@@ -399,6 +406,10 @@ namespace Atlas.Api.Migrations
                     b.Navigation("Property");
                 });
 
+            modelBuilder.Entity("Atlas.Api.Models.Listing", b =>
+                {
+                    b.Navigation("Bookings");
+                });
 #pragma warning restore 612, 618
         }
     }

--- a/Atlas.Api/Migrations/20250728160020_FixListingBookingNavigation.cs
+++ b/Atlas.Api/Migrations/20250728160020_FixListingBookingNavigation.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Atlas.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class FixListingBookingNavigation : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}

--- a/Atlas.Api/Models/Booking.cs
+++ b/Atlas.Api/Models/Booking.cs
@@ -12,7 +12,7 @@ namespace Atlas.Api.Models
         [ForeignKey(nameof(Listing))]
         public int ListingId { get; set; }
 
-        public Listing Listing { get; set; }
+        public Listing Listing { get; set; } = null!;
 
         [Required]
         [ForeignKey(nameof(Property))]


### PR DESCRIPTION
## Summary
- ensure `Booking.Listing` is non-nullable
- configure `Listing.Bookings` navigation and delete behavior
- update EF Core model snapshot and add empty migration

## Testing
- `dotnet ef migrations add FixListingBookingNavigation`
- `dotnet ef database update` *(fails: LocalDB not supported)*
- `dotnet test AtlasHomestays.sln` *(fails: tests cannot connect to DB)*

------
https://chatgpt.com/codex/tasks/task_e_68879ae975ac832baa916d004f0d5cd6