### PR TITLE
Reset test DB via migrations

### DIFF
--- a/Atlas.Api.IntegrationTests/CustomWebApplicationFactory.cs
+++ b/Atlas.Api.IntegrationTests/CustomWebApplicationFactory.cs
@@ -23,9 +23,7 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>
             services.AddDbContext<AppDbContext>(options =>
                 options.UseSqlServer("Server=(localdb)\\MSSQLLocalDB;Database=AtlasHomestays_TestDb;Trusted_Connection=True;"));
 
-            var sp = services.BuildServiceProvider();
-            var scopeFactory = sp.GetRequiredService<IServiceScopeFactory>();
-            using (var scope = scopeFactory.CreateScope())
+            using (var scope = services.BuildServiceProvider().CreateScope())
             {
                 var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
                 db.Database.EnsureDeleted();

--- a/Atlas.Api.IntegrationTests/IntegrationTestBase.cs
+++ b/Atlas.Api.IntegrationTests/IntegrationTestBase.cs
@@ -28,7 +28,7 @@ public abstract class IntegrationTestBase : IClassFixture<CustomWebApplicationFa
         using var scope = Factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
         await db.Database.EnsureDeletedAsync();
-        await db.Database.EnsureCreatedAsync();
+        await db.Database.MigrateAsync();
 
         if (!await db.Properties.AnyAsync())
         {


### PR DESCRIPTION
## Summary
- drop and recreate test database using `EnsureDeleted()` and `Migrate()` in `CustomWebApplicationFactory`
- use the same reset logic in `IntegrationTestBase`

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887a17c1e3c832b9c3411ee623c5408