### PR TITLE
Add migration for integration test DB sync

### DIFF
--- a/Atlas.Api/Migrations/20250728162421_SyncModelWithDb_ForIntegrationTests.Designer.cs
+++ b/Atlas.Api/Migrations/20250728162421_SyncModelWithDb_ForIntegrationTests.Designer.cs
@@ -4,6 +4,7 @@ using Atlas.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Atlas.Api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250728162421_SyncModelWithDb_ForIntegrationTests")]
+    partial class SyncModelWithDb_ForIntegrationTests
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Atlas.Api/Migrations/20250728162421_SyncModelWithDb_ForIntegrationTests.cs
+++ b/Atlas.Api/Migrations/20250728162421_SyncModelWithDb_ForIntegrationTests.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Atlas.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class SyncModelWithDb_ForIntegrationTests : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Bookings_Listings_ListingId",
+                table: "Bookings");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Bookings_Listings_ListingId",
+                table: "Bookings",
+                column: "ListingId",
+                principalTable: "Listings",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Bookings_Listings_ListingId",
+                table: "Bookings");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Bookings_Listings_ListingId",
+                table: "Bookings",
+                column: "ListingId",
+                principalTable: "Listings",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add EF Core migration `SyncModelWithDb_ForIntegrationTests`
- update the model snapshot with the `Listing.Bookings` navigation

## Testing
- `dotnet ef --startup-project Atlas.Api/Atlas.Api.csproj --project Atlas.Api/Atlas.Api.csproj database update -- --environment Test` *(fails: could not connect to SQL Server)*
- `dotnet test Atlas.Api.Tests/Atlas.Api.Tests.csproj --no-build` *(fails: MSB4181 during VSTest)*

------
https://chatgpt.com/codex/tasks/task_e_6887a39033dc832b8d1d35495f40e8c0