### PR TITLE
Fix integration DB conflicts

### DIFF
--- a/Atlas.Api.IntegrationTests/CustomWebApplicationFactory.cs
+++ b/Atlas.Api.IntegrationTests/CustomWebApplicationFactory.cs
@@ -1,5 +1,6 @@
 using Atlas.Api;
 using Atlas.Api.Data;
+using System;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
@@ -14,14 +15,19 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         builder.UseEnvironment("Test");
-        Environment.SetEnvironmentVariable("DEFAULT_CONNECTION", "Server=(localdb)\\MSSQLLocalDB;Database=AtlasHomestays_TestDb;Trusted_Connection=True;");
+
+        // Create a unique database name for each test run to avoid
+        // conflicts with leftover connections or data from previous runs.
+        var dbName = $"AtlasHomestays_TestDb_{Guid.NewGuid()}";
+        var connectionString = $"Server=(localdb)\\MSSQLLocalDB;Database={dbName};Trusted_Connection=True;";
+        Environment.SetEnvironmentVariable("DEFAULT_CONNECTION", connectionString);
 
         builder.ConfigureServices(services =>
         {
             services.RemoveAll<DbContextOptions<AppDbContext>>();
 
             services.AddDbContext<AppDbContext>(options =>
-                options.UseSqlServer("Server=(localdb)\\MSSQLLocalDB;Database=AtlasHomestays_TestDb;Trusted_Connection=True;"));
+                options.UseSqlServer(connectionString));
 
             using (var scope = services.BuildServiceProvider().CreateScope())
             {


### PR DESCRIPTION
## Summary
- use unique SQL Server DB per integration test run
- delete and migrate DB in fixture

## Testing
- `dotnet build AtlasHomestays.sln -c Debug`
- `dotnet test Atlas.Api.Tests/Atlas.Api.Tests.csproj --no-build` *(fails: Assert.IsType Failure)*
- `dotnet test Atlas.Api.IntegrationTests/Atlas.Api.IntegrationTests.csproj --no-build` *(fails: LocalDB not supported)*

------
https://chatgpt.com/codex/tasks/task_e_6887a7bceac4832b9fa6154fd59078a2