### PR TITLE
Fix cascade paths for bookings

### DIFF
--- a/Atlas.Api.IntegrationTests/DeleteBehaviorTests.cs
+++ b/Atlas.Api.IntegrationTests/DeleteBehaviorTests.cs
@@ -1,0 +1,25 @@
+using Atlas.Api.Data;
+using Atlas.Api.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Atlas.Api.IntegrationTests;
+
+public class DeleteBehaviorTests : IntegrationTestBase
+{
+    public DeleteBehaviorTests(CustomWebApplicationFactory factory) : base(factory) { }
+
+    [Fact]
+    public void OnModelCreating_AllCascadeInIntegrationTest()
+    {
+        using var scope = Factory.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var entity = context.Model.FindEntityType(typeof(Booking))!;
+
+        foreach (var fk in entity.GetForeignKeys())
+        {
+            Assert.Equal(DeleteBehavior.Cascade, fk.DeleteBehavior);
+        }
+    }
+}

--- a/Atlas.Api.Tests/DeleteBehaviorTests.cs
+++ b/Atlas.Api.Tests/DeleteBehaviorTests.cs
@@ -1,0 +1,27 @@
+using Atlas.Api.Data;
+using Atlas.Api.Models;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Atlas.Api.Tests;
+
+public class DeleteBehaviorTests
+{
+    [Fact]
+    public void OnModelCreating_UsesCascadeOnListingOnly()
+    {
+        Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", null);
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase("DeleteBehaviorTest")
+            .Options;
+
+        using var context = new AppDbContext(options);
+        var entity = context.Model.FindEntityType(typeof(Booking))!;
+        var fks = entity.GetForeignKeys();
+
+        Assert.Equal(DeleteBehavior.Restrict, fks.Single(f => f.Properties.Any(p => p.Name == nameof(Booking.GuestId))).DeleteBehavior);
+        Assert.Equal(DeleteBehavior.Cascade, fks.Single(f => f.Properties.Any(p => p.Name == nameof(Booking.ListingId))).DeleteBehavior);
+        Assert.Equal(DeleteBehavior.Restrict, fks.Single(f => f.Properties.Any(p => p.Name == nameof(Booking.BankAccountId))).DeleteBehavior);
+        Assert.Equal(DeleteBehavior.Restrict, fks.Single(f => f.Properties.Any(p => p.Name == nameof(Booking.PropertyId))).DeleteBehavior);
+    }
+}

--- a/Atlas.Api/Data/AppDbContext.cs
+++ b/Atlas.Api/Data/AppDbContext.cs
@@ -15,9 +15,9 @@ namespace Atlas.Api.Data
             base.OnModelCreating(modelBuilder);
 
             var env = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
-            var deleteBehavior = env == "IntegrationTest"
-                ? DeleteBehavior.Cascade
-                : DeleteBehavior.Restrict;
+
+            // Use cascade deletes for integration tests. In other environments
+            // apply cascade to only one FK to avoid multiple cascade paths.
 
             modelBuilder.Entity<Booking>()
                 .Property(b => b.AmountReceived)
@@ -41,29 +41,58 @@ namespace Atlas.Api.Data
                 .HasPrecision(5, 2);
 
 
-            modelBuilder.Entity<Booking>()
-                .HasOne(b => b.Guest)
-                .WithMany()
-                .HasForeignKey(b => b.GuestId)
-                .OnDelete(deleteBehavior);
+            if (env == "IntegrationTest")
+            {
+                modelBuilder.Entity<Booking>()
+                    .HasOne(b => b.Guest)
+                    .WithMany()
+                    .HasForeignKey(b => b.GuestId)
+                    .OnDelete(DeleteBehavior.Cascade);
 
-            modelBuilder.Entity<Booking>()
-                .HasOne(b => b.Listing)
-                .WithMany(l => l.Bookings)
-                .HasForeignKey(b => b.ListingId)
-                .OnDelete(deleteBehavior);
+                modelBuilder.Entity<Booking>()
+                    .HasOne(b => b.Listing)
+                    .WithMany(l => l.Bookings)
+                    .HasForeignKey(b => b.ListingId)
+                    .OnDelete(DeleteBehavior.Cascade);
 
-            modelBuilder.Entity<Booking>()
-                .HasOne(b => b.BankAccount)
-                .WithMany()
-                .HasForeignKey(b => b.BankAccountId)
-                .OnDelete(deleteBehavior);
+                modelBuilder.Entity<Booking>()
+                    .HasOne(b => b.BankAccount)
+                    .WithMany()
+                    .HasForeignKey(b => b.BankAccountId)
+                    .OnDelete(DeleteBehavior.Cascade);
 
-            modelBuilder.Entity<Booking>()
-                .HasOne(b => b.Property)
-                .WithMany()
-                .HasForeignKey(b => b.PropertyId)
-                .OnDelete(deleteBehavior);
+                modelBuilder.Entity<Booking>()
+                    .HasOne(b => b.Property)
+                    .WithMany()
+                    .HasForeignKey(b => b.PropertyId)
+                    .OnDelete(DeleteBehavior.Cascade);
+            }
+            else
+            {
+                modelBuilder.Entity<Booking>()
+                    .HasOne(b => b.Guest)
+                    .WithMany()
+                    .HasForeignKey(b => b.GuestId)
+                    .OnDelete(DeleteBehavior.Restrict);
+
+                modelBuilder.Entity<Booking>()
+                    .HasOne(b => b.Listing)
+                    .WithMany(l => l.Bookings)
+                    .HasForeignKey(b => b.ListingId)
+                    .OnDelete(DeleteBehavior.Cascade);
+
+                modelBuilder.Entity<Booking>()
+                    .HasOne(b => b.BankAccount)
+                    .WithMany()
+                    .HasForeignKey(b => b.BankAccountId)
+                    .OnDelete(DeleteBehavior.Restrict);
+
+                modelBuilder.Entity<Booking>()
+                    .HasOne(b => b.Property)
+                    .WithMany()
+                    .HasForeignKey(b => b.PropertyId)
+                    .OnDelete(DeleteBehavior.Restrict);
+            }
         }
 
         public DbSet<Property> Properties { get; set; }


### PR DESCRIPTION
## Summary
- set cascade for Listing only in production to avoid cycle errors
- keep cascade for integration tests
- add unit and integration tests for delete behavior

## Testing
- `dotnet test Atlas.Api.Tests/Atlas.Api.Tests.csproj --filter DeleteBehaviorTests`
- `dotnet test Atlas.Api.IntegrationTests/Atlas.Api.IntegrationTests.csproj --filter DeleteBehaviorTests` *(fails: LocalDB is not supported)*

------
https://chatgpt.com/codex/tasks/task_e_6887c3a1eee0832baf6b2e00463b901e