### PR TITLE
Fix delete behavior env logic

### DIFF
--- a/Atlas.Api.IntegrationTests/DeleteBehaviorTests.cs
+++ b/Atlas.Api.IntegrationTests/DeleteBehaviorTests.cs
@@ -1,0 +1,26 @@
+using Atlas.Api.Data;
+using Atlas.Api.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using System.Linq;
+using Xunit;
+
+namespace Atlas.Api.IntegrationTests;
+
+public class DeleteBehaviorTests : IntegrationTestBase
+{
+    public DeleteBehaviorTests(CustomWebApplicationFactory factory) : base(factory) { }
+
+    [Fact]
+    public void OnModelCreating_CascadeOnlyListing()
+    {
+        using var scope = Factory.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var entity = context.Model.FindEntityType(typeof(Booking))!;
+        var fks = entity.GetForeignKeys().ToList();
+
+        var listingFk = fks.Single(fk => fk.PrincipalEntityType.ClrType == typeof(Listing));
+        Assert.Equal(DeleteBehavior.Cascade, listingFk.DeleteBehavior);
+        Assert.All(fks.Where(fk => fk != listingFk), fk => Assert.Equal(DeleteBehavior.Restrict, fk.DeleteBehavior));
+    }
+}

--- a/Atlas.Api.Tests/DeleteBehaviorTests.cs
+++ b/Atlas.Api.Tests/DeleteBehaviorTests.cs
@@ -1,0 +1,52 @@
+using System;
+using Atlas.Api.Data;
+using Atlas.Api.Models;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Atlas.Api.Tests;
+
+public class DeleteBehaviorTests
+{
+    [Fact]
+    public void OnModelCreating_RestrictOutsideIntegrationTest()
+    {
+        Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", null);
+        var services = new ServiceCollection();
+        services.AddEntityFrameworkInMemoryDatabase();
+        var provider = services.BuildServiceProvider();
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .UseInternalServiceProvider(provider)
+            .Options;
+
+        using var context = new AppDbContext(options);
+        var entity = context.Model.FindEntityType(typeof(Booking))!;
+        var fks = entity.GetForeignKeys();
+
+        Assert.All(fks, fk => Assert.Equal(DeleteBehavior.Restrict, fk.DeleteBehavior));
+    }
+
+    [Fact]
+    public void OnModelCreating_CascadeOnlyListingInIntegrationTest()
+    {
+        Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "IntegrationTest");
+        var services = new ServiceCollection();
+        services.AddEntityFrameworkInMemoryDatabase();
+        var provider = services.BuildServiceProvider();
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .UseInternalServiceProvider(provider)
+            .Options;
+
+        using var context = new AppDbContext(options);
+        var entity = context.Model.FindEntityType(typeof(Booking))!;
+        var fks = entity.GetForeignKeys().ToList();
+
+        var listingFk = fks.Single(fk => fk.PrincipalEntityType.ClrType == typeof(Listing));
+        Assert.Equal(DeleteBehavior.Cascade, listingFk.DeleteBehavior);
+        Assert.All(fks.Where(fk => fk != listingFk), fk => Assert.Equal(DeleteBehavior.Restrict, fk.DeleteBehavior));
+    }
+}

--- a/Atlas.Api/Data/AppDbContext.cs
+++ b/Atlas.Api/Data/AppDbContext.cs
@@ -15,9 +15,7 @@ namespace Atlas.Api.Data
             base.OnModelCreating(modelBuilder);
 
             var env = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
-            var deleteBehavior = env == "IntegrationTest"
-                ? DeleteBehavior.Cascade
-                : DeleteBehavior.Restrict;
+            var isIntegrationTest = env == "IntegrationTest";
 
             modelBuilder.Entity<Booking>()
                 .Property(b => b.AmountReceived)
@@ -45,25 +43,25 @@ namespace Atlas.Api.Data
                 .HasOne(b => b.Guest)
                 .WithMany()
                 .HasForeignKey(b => b.GuestId)
-                .OnDelete(deleteBehavior);
+                .OnDelete(DeleteBehavior.Restrict);
 
             modelBuilder.Entity<Booking>()
                 .HasOne(b => b.Listing)
                 .WithMany(l => l.Bookings)
                 .HasForeignKey(b => b.ListingId)
-                .OnDelete(deleteBehavior);
+                .OnDelete(isIntegrationTest ? DeleteBehavior.Cascade : DeleteBehavior.Restrict);
 
             modelBuilder.Entity<Booking>()
                 .HasOne(b => b.BankAccount)
                 .WithMany()
                 .HasForeignKey(b => b.BankAccountId)
-                .OnDelete(deleteBehavior);
+                .OnDelete(DeleteBehavior.Restrict);
 
             modelBuilder.Entity<Booking>()
                 .HasOne(b => b.Property)
                 .WithMany()
                 .HasForeignKey(b => b.PropertyId)
-                .OnDelete(deleteBehavior);
+                .OnDelete(DeleteBehavior.Restrict);
         }
 
         public DbSet<Property> Properties { get; set; }


### PR DESCRIPTION
## Summary
- refine environment-specific delete behavior
- check cascade is limited to listing relationship in tests

## Testing
- `dotnet test Atlas.Api.Tests/Atlas.Api.Tests.csproj --filter DeleteBehaviorTests -v minimal`
- `dotnet test Atlas.Api.IntegrationTests/Atlas.Api.IntegrationTests.csproj --filter DeleteBehaviorTests -v minimal` *(fails: LocalDB is not supported)*

------
https://chatgpt.com/codex/tasks/task_e_6887c3a1eee0832baf6b2e00463b901e