### PR TITLE
Fix cascade path by removing Booking.PropertyId

### DIFF
--- a/Atlas.Api.IntegrationTests/BookingsApiTests.cs
+++ b/Atlas.Api.IntegrationTests/BookingsApiTests.cs
@@ -47,7 +47,6 @@ public class BookingsApiTests : IntegrationTestBase
         await db.SaveChangesAsync();
         var booking = new Booking
         {
-            PropertyId = property.Id,
             ListingId = listing.Id,
             GuestId = guest.Id,
             BookingSource = "airbnb",
@@ -307,7 +306,6 @@ public class BookingsApiTests : IntegrationTestBase
         {
             Id = data.booking.Id,
             ListingId = data.booking.ListingId,
-            PropertyId = data.booking.PropertyId,
             GuestId = data.booking.GuestId,
             BookingSource = data.booking.BookingSource,
             CheckinDate = data.booking.CheckinDate,

--- a/Atlas.Api.IntegrationTests/DataSeeder.cs
+++ b/Atlas.Api.IntegrationTests/DataSeeder.cs
@@ -53,7 +53,6 @@ public static class DataSeeder
     {
         var booking = new Booking
         {
-            PropertyId = property.Id,
             ListingId = listing.Id,
             Listing = listing,
             GuestId = guest.Id,

--- a/Atlas.Api.IntegrationTests/PropertiesApiTests.cs
+++ b/Atlas.Api.IntegrationTests/PropertiesApiTests.cs
@@ -51,7 +51,6 @@ public class PropertiesApiTests : IntegrationTestBase
 
         var booking = new Booking
         {
-            PropertyId = property.Id,
             ListingId = listing.Id,
             GuestId = guest.Id,
             BookingSource = "airbnb",

--- a/Atlas.Api.Tests/DeleteBehaviorTests.cs
+++ b/Atlas.Api.Tests/DeleteBehaviorTests.cs
@@ -22,6 +22,5 @@ public class DeleteBehaviorTests
         Assert.Equal(DeleteBehavior.Restrict, fks.Single(f => f.Properties.Any(p => p.Name == nameof(Booking.GuestId))).DeleteBehavior);
         Assert.Equal(DeleteBehavior.Cascade, fks.Single(f => f.Properties.Any(p => p.Name == nameof(Booking.ListingId))).DeleteBehavior);
         Assert.Equal(DeleteBehavior.Restrict, fks.Single(f => f.Properties.Any(p => p.Name == nameof(Booking.BankAccountId))).DeleteBehavior);
-        Assert.Equal(DeleteBehavior.Restrict, fks.Single(f => f.Properties.Any(p => p.Name == nameof(Booking.PropertyId))).DeleteBehavior);
     }
 }

--- a/Atlas.Api/Data/AppDbContext.cs
+++ b/Atlas.Api/Data/AppDbContext.cs
@@ -61,11 +61,6 @@ namespace Atlas.Api.Data
                     .HasForeignKey(b => b.BankAccountId)
                     .OnDelete(DeleteBehavior.Cascade);
 
-                modelBuilder.Entity<Booking>()
-                    .HasOne(b => b.Property)
-                    .WithMany()
-                    .HasForeignKey(b => b.PropertyId)
-                    .OnDelete(DeleteBehavior.Cascade);
             }
             else
             {
@@ -87,11 +82,6 @@ namespace Atlas.Api.Data
                     .HasForeignKey(b => b.BankAccountId)
                     .OnDelete(DeleteBehavior.Restrict);
 
-                modelBuilder.Entity<Booking>()
-                    .HasOne(b => b.Property)
-                    .WithMany()
-                    .HasForeignKey(b => b.PropertyId)
-                    .OnDelete(DeleteBehavior.Restrict);
             }
         }
 

--- a/Atlas.Api/Migrations/20250729055153_RemoveBookingProperty.Designer.cs
+++ b/Atlas.Api/Migrations/20250729055153_RemoveBookingProperty.Designer.cs
@@ -4,6 +4,7 @@ using Atlas.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Atlas.Api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250729055153_RemoveBookingProperty")]
+    partial class RemoveBookingProperty
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Atlas.Api/Migrations/20250729055153_RemoveBookingProperty.cs
+++ b/Atlas.Api/Migrations/20250729055153_RemoveBookingProperty.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Atlas.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveBookingProperty : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Bookings_Properties_PropertyId",
+                table: "Bookings");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Bookings_PropertyId",
+                table: "Bookings");
+
+            migrationBuilder.DropColumn(
+                name: "PropertyId",
+                table: "Bookings");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "PropertyId",
+                table: "Bookings",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Bookings_PropertyId",
+                table: "Bookings",
+                column: "PropertyId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Bookings_Properties_PropertyId",
+                table: "Bookings",
+                column: "PropertyId",
+                principalTable: "Properties",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+    }
+}

--- a/Atlas.Api/Models/Booking.cs
+++ b/Atlas.Api/Models/Booking.cs
@@ -14,12 +14,6 @@ namespace Atlas.Api.Models
 
         public Listing Listing { get; set; } = null!;
 
-        [Required]
-        [ForeignKey(nameof(Property))]
-        public int PropertyId { get; set; }
-
-        [JsonIgnore]
-        public Property? Property { get; set; }
 
         [Required]
         public int GuestId { get; set; }


### PR DESCRIPTION
## Summary
- refactor `Booking` model to reference only `Listing`
- update `AppDbContext` relationships
- update data seeder and tests
- add migration to drop obsolete `PropertyId` column

## Testing
- `dotnet test --verbosity normal`

🔁 IMPORTANT: Ensure environment-specific behavior is correctly applied:
- ✅ Use `LocalDb` for integration tests, and SQL Server for production.
- ✅ Use test connection strings for integration tests; use Azure/App Service connection strings in production.
- ✅ Apply `DeleteBehavior.Cascade` in integration tests for cleanup; use `DeleteBehavior.Restrict` in production to prevent data loss.
- ✅ Seed minimal or mock data inline for tests; avoid seeding production data unless explicitly instructed.
- ✅ Wrap integration test logic in transactions with rollback for isolation; avoid transactions for production logic.
🧪 TEST COVERAGE ENFORCEMENT:
- ✅ Add or update **unit tests** and **integration tests** for any new logic added or modified.
- ✅ Ensure each controller and service method is **covered by tests**, unless explicitly excluded.
- 🚫 Do not include files from the `/Migrations/` folder in code coverage reports (exclude by file path or folder name).

------
https://chatgpt.com/codex/tasks/task_e_68885f2e5b58832b9791ca13f27e2f48