### PR TITLE
Configure LocalDb for development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # Ignore build artifacts
 **/bin/
 **/obj/
+.env.local

--- a/Atlas.Api.IntegrationTests/CustomWebApplicationFactory.cs
+++ b/Atlas.Api.IntegrationTests/CustomWebApplicationFactory.cs
@@ -22,10 +22,11 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>
             Environment.GetEnvironmentVariable("Atlas_TestDb") ??
             $"Server=(localdb)\\MSSQLLocalDB;Database={dbName};Trusted_Connection=True;";
 
+        Environment.SetEnvironmentVariable("DEFAULT_CONNECTION", connectionString);
+
         builder.ConfigureServices(services =>
         {
             services.RemoveAll<DbContextOptions<AppDbContext>>();
-            Environment.SetEnvironmentVariable("DEFAULT_CONNECTION", connectionString);
             services.AddDbContext<AppDbContext>(o =>
                 o.UseSqlServer(connectionString));
 

--- a/Atlas.Api/Program.cs
+++ b/Atlas.Api/Program.cs
@@ -14,6 +14,10 @@ namespace Atlas.Api
         {
             var builder = WebApplication.CreateBuilder(args);
 
+            builder.Configuration
+                .AddJsonFile(".env.local", optional: true)
+                .AddEnvironmentVariables();
+
 
             // Add services
             builder.Services.AddCors(options =>
@@ -49,13 +53,8 @@ namespace Atlas.Api
             // or environment variables. Azure App Service typically injects the
             // connection string as `ConnectionStrings__DefaultConnection` so we
             // read from configuration first which already checks that variable.
-            var connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
-
-            // Fall back to older environment variable name if provided
-            if (string.IsNullOrWhiteSpace(connectionString))
-            {
-                connectionString = Environment.GetEnvironmentVariable("DEFAULT_CONNECTION");
-            }
+            var connectionString = Environment.GetEnvironmentVariable("DEFAULT_CONNECTION")
+                ?? builder.Configuration.GetConnectionString("DefaultConnection");
 
             if (string.IsNullOrWhiteSpace(connectionString))
             {

--- a/Atlas.Api/appsettings.Development.json
+++ b/Atlas.Api/appsettings.Development.json
@@ -1,4 +1,7 @@
 {
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=LAPTOP-SAI7F8A5\\Sreekar;Database=AtlasHomestays_Local;Trusted_Connection=True;"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",


### PR DESCRIPTION
## Summary
- load `.env.local` settings and environment vars before building the app
- default to the `DEFAULT_CONNECTION` environment variable first
- add LocalDb connection string to `appsettings.Development.json`
- ensure integration tests set `DEFAULT_CONNECTION` before building the host
- ignore `.env.local`

## Testing
- `dotnet test` *(fails: LocalDB is not supported on this platform)*

------
https://chatgpt.com/codex/tasks/task_e_68889e5f187c832b9bd9dd95fdeddc4d