### PR TITLE
Fix migrations assembly for integration tests

### DIFF
--- a/Atlas.Api.IntegrationTests/CustomWebApplicationFactory.cs
+++ b/Atlas.Api.IntegrationTests/CustomWebApplicationFactory.cs
@@ -28,30 +28,8 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>
         {
             services.RemoveAll<DbContextOptions<AppDbContext>>();
             services.AddDbContext<AppDbContext>(o =>
-                o.UseSqlServer(connectionString));
-
-            using (var scope = services.BuildServiceProvider().CreateScope())
-            {
-                var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
-
-                db.Database.EnsureDeleted();   // Clean test schema
-                db.Database.Migrate();         // Apply EF Core migrations
-
-                if (!db.Properties.Any())
-                {
-                    db.Properties.Add(new Atlas.Api.Models.Property
-                    {
-                        Name = "Test Villa",
-                        Address = "Seed Address",
-                        Type = "Villa",
-                        OwnerName = "Owner",
-                        ContactPhone = "000",
-                        CommissionPercent = 10,
-                        Status = "Active"
-                    });
-                    db.SaveChanges();
-                }
-            }
+                o.UseSqlServer(connectionString, sqlOptions =>
+                    sqlOptions.MigrationsAssembly(typeof(AppDbContext).Assembly.FullName)));
         });
     }
 }

--- a/Atlas.Api.IntegrationTests/IntegrationTestBase.cs
+++ b/Atlas.Api.IntegrationTests/IntegrationTestBase.cs
@@ -14,13 +14,6 @@ public abstract class IntegrationTestBase : IClassFixture<CustomWebApplicationFa
     {
         Factory = factory;
 
-        using (var scope = factory.Services.CreateScope())
-        {
-            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
-            db.Database.EnsureDeleted();   // Clean test schema
-            db.Database.Migrate();         // Apply EF Core migrations
-        }
-
         Client = factory.CreateClient();
     }
 


### PR DESCRIPTION
## Summary
- configure `MigrationsAssembly` for EF Core in integration test factory
- rely on `ResetDatabase` for schema setup in integration tests

## Testing
- `dotnet test ./Atlas.Api.Tests/Atlas.Api.Tests.csproj --no-build`
- `dotnet test` *(fails: SQL Server LocalDb not available)*

------
https://chatgpt.com/codex/tasks/task_e_6888c97fe414832bb53711dad54fe85b