### PR TITLE
Fix concurrency error handling in bookings

### DIFF
--- a/Atlas.Api/Controllers/BookingsController.cs
+++ b/Atlas.Api/Controllers/BookingsController.cs
@@ -201,13 +201,16 @@ namespace Atlas.Api.Controllers
                 existingBooking.Notes = booking.Notes;
                 existingBooking.BankAccountId = booking.BankAccountId;
 
-                await _context.SaveChangesAsync();
+                try
+                {
+                    await _context.SaveChangesAsync();
+                }
+                catch (DbUpdateConcurrencyException ex)
+                {
+                    _logger.LogError(ex, "Concurrency error updating booking {BookingId}", id);
+                    return StatusCode(500, "A concurrency error occurred while updating the booking.");
+                }
                 return NoContent();
-            }
-            catch (DbUpdateConcurrencyException ex)
-            {
-                _logger.LogError(ex, "Concurrency error updating booking {BookingId}", id);
-                return StatusCode(500, "Concurrency error updating booking");
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary
- catch DbUpdateConcurrencyException when saving updated bookings
- mock SaveChangesAsync in concurrency error test

## Testing
- `dotnet test --filter "FullyQualifiedName=Atlas.Api.Tests.BookingsControllerTests.Update_ReturnsConcurrencyError_WhenSaveFails" -v m`
- `dotnet test` *(fails: LocalDB is not supported)*

------
https://chatgpt.com/codex/tasks/task_e_6888dee51cec832ba47ebfc59d8d54a1