### PR TITLE
Set default PaymentStatus to Paid

### DIFF
--- a/Atlas.Api.IntegrationTests/BookingsApiTests.cs
+++ b/Atlas.Api.IntegrationTests/BookingsApiTests.cs
@@ -144,7 +144,7 @@ public class BookingsApiTests : IntegrationTestBase
     }
 
     [Fact]
-    public async Task Post_ReturnsBadRequest_WhenPaymentStatusMissing_Alt()
+    public async Task Post_CreatesBooking_WhenPaymentStatusMissing_Alt()
     {
         using var scope = Factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
@@ -166,7 +166,7 @@ public class BookingsApiTests : IntegrationTestBase
         };
 
         var response = await Client.PostAsJsonAsync("/api/bookings", newBooking);
-        Assert.Equal(System.Net.HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal(System.Net.HttpStatusCode.Created, response.StatusCode);
     }
 
     [Fact]
@@ -208,7 +208,7 @@ public class BookingsApiTests : IntegrationTestBase
     }
 
     [Fact]
-    public async Task Put_ReturnsBadRequest_WhenPaymentStatusMissing_Alt()
+    public async Task Put_UpdatesBooking_WhenPaymentStatusMissing_Alt()
     {
         using var scope = Factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
@@ -235,7 +235,7 @@ public class BookingsApiTests : IntegrationTestBase
         };
 
         var response = await Client.PutAsJsonAsync($"/api/bookings/{id}", payload);
-        Assert.Equal(System.Net.HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal(System.Net.HttpStatusCode.NoContent, response.StatusCode);
     }
 
     [Fact]
@@ -265,7 +265,7 @@ public class BookingsApiTests : IntegrationTestBase
     }
 
     [Fact]
-    public async Task Post_ReturnsBadRequest_WhenPaymentStatusMissing()
+    public async Task Post_CreatesBooking_WhenPaymentStatusMissing()
     {
         using var scope = Factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
@@ -287,11 +287,11 @@ public class BookingsApiTests : IntegrationTestBase
 
         var response = await Client.PostAsJsonAsync("/api/bookings", request);
 
-        Assert.Equal(System.Net.HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal(System.Net.HttpStatusCode.Created, response.StatusCode);
     }
 
     [Fact]
-    public async Task Put_ReturnsBadRequest_WhenPaymentStatusMissing()
+    public async Task Put_UpdatesBooking_WhenPaymentStatusMissing()
     {
         using var scope = Factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
@@ -317,7 +317,7 @@ public class BookingsApiTests : IntegrationTestBase
 
         var response = await Client.PutAsJsonAsync($"/api/bookings/{data.booking.Id}", request);
 
-        Assert.Equal(System.Net.HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal(System.Net.HttpStatusCode.NoContent, response.StatusCode);
     }
 
     [Fact]

--- a/Atlas.Api.IntegrationTests/DataSeeder.cs
+++ b/Atlas.Api.IntegrationTests/DataSeeder.cs
@@ -58,7 +58,7 @@ public static class DataSeeder
             GuestId = guest.Id,
             Guest = guest,
             BookingSource = "airbnb",
-            PaymentStatus = "Pending",
+            PaymentStatus = "Paid",
             CheckinDate = DateTime.UtcNow.Date,
             CheckoutDate = DateTime.UtcNow.Date.AddDays(1),
             AmountReceived = 100,

--- a/Atlas.Api.Tests/BookingDtoTests.cs
+++ b/Atlas.Api.Tests/BookingDtoTests.cs
@@ -5,10 +5,10 @@ namespace Atlas.Api.Tests;
 public class BookingDtoTests
 {
     [Fact]
-    public void PaymentStatus_DefaultsToPending()
+    public void PaymentStatus_DefaultsToPaid()
     {
         var dto = new BookingDto();
-        Assert.Equal("Pending", dto.PaymentStatus);
+        Assert.Equal("Paid", dto.PaymentStatus);
     }
 
     [Fact]

--- a/Atlas.Api.Tests/BookingModelTests.cs
+++ b/Atlas.Api.Tests/BookingModelTests.cs
@@ -13,10 +13,10 @@ public class BookingModelTests
             GuestId = 1,
             BookingSource = "b",
             Notes = "n",
-            PaymentStatus = "Pending"
+            PaymentStatus = "Paid"
         };
 
-        Assert.Equal("Pending", booking.PaymentStatus);
+        Assert.Equal("Paid", booking.PaymentStatus);
         Assert.True((DateTime.UtcNow - booking.CreatedAt).TotalSeconds < 5);
     }
 }

--- a/Atlas.Api/Controllers/BookingsController.cs
+++ b/Atlas.Api/Controllers/BookingsController.cs
@@ -125,7 +125,7 @@ namespace Atlas.Api.Controllers
                     GuestId = guest.Id,
                     Guest = guest,
                     BookingSource = request.BookingSource,
-                    PaymentStatus = string.IsNullOrWhiteSpace(request.PaymentStatus) ? "Pending" : request.PaymentStatus,
+                    PaymentStatus = string.IsNullOrWhiteSpace(request.PaymentStatus) ? "Paid" : request.PaymentStatus,
                     CheckinDate = request.CheckinDate,
                     CheckoutDate = request.CheckoutDate,
                     AmountReceived = request.AmountReceived,

--- a/Atlas.Api/DTOs/BookingDto.cs
+++ b/Atlas.Api/DTOs/BookingDto.cs
@@ -18,6 +18,6 @@ namespace Atlas.Api.DTOs
         public string Notes { get; set; } = string.Empty;
         public DateTime CreatedAt { get; set; }
 
-        public string PaymentStatus { get; set; } = "Pending";
+        public string PaymentStatus { get; set; } = "Paid";
     }
 }

--- a/Atlas.Api/DTOs/CreateBookingRequest.cs
+++ b/Atlas.Api/DTOs/CreateBookingRequest.cs
@@ -19,7 +19,7 @@ namespace Atlas.Api.DTOs
         public int GuestsActual { get; set; }
         public decimal ExtraGuestCharge { get; set; }
         [Required]
-        public string? PaymentStatus { get; set; }
+        public string? PaymentStatus { get; set; } = "Paid";
 
         public string? Notes { get; set; }
     }

--- a/Atlas.Api/DTOs/UpdateBookingRequest.cs
+++ b/Atlas.Api/DTOs/UpdateBookingRequest.cs
@@ -19,7 +19,7 @@ namespace Atlas.Api.DTOs
         public string BookingSource { get; set; } = string.Empty;
 
         [Required]
-        public string PaymentStatus { get; set; } = string.Empty;
+        public string PaymentStatus { get; set; } = "Paid";
 
         public decimal AmountReceived { get; set; }
         public int? BankAccountId { get; set; }

--- a/Atlas.Api/Models/Booking.cs
+++ b/Atlas.Api/Models/Booking.cs
@@ -28,7 +28,7 @@ namespace Atlas.Api.Models
         public string BookingSource { get; set; } = string.Empty;
 
         [Required]
-        public string PaymentStatus { get; set; } = "Pending";
+        public string PaymentStatus { get; set; } = "Paid";
         public decimal AmountReceived { get; set; }
         [ForeignKey(nameof(BankAccount))]
         public int? BankAccountId { get; set; }


### PR DESCRIPTION
## Summary
- default PaymentStatus to `Paid` across models and DTOs
- set controllers and seed data to use `Paid`
- update integration tests for new default
- update unit tests for new default

## Testing
- `dotnet test` *(fails: database connection errors)*

🔁 IMPORTANT: Ensure environment-specific behavior is correctly applied:
- ✅ Use `LocalDb` for integration tests, and SQL Server for production.
- ✅ Use test connection strings for integration tests; use Azure/App Service connection strings in production.
- ✅ Apply `DeleteBehavior.Cascade` in integration tests for cleanup; use `DeleteBehavior.Restrict` in production to prevent data loss.
- ✅ Seed minimal or mock data inline for tests; avoid seeding production data unless explicitly instructed.
- ✅ Wrap integration test logic in transactions with rollback for isolation; avoid transactions for production logic.
🧪 TEST COVERAGE ENFORCEMENT:
- ✅ Add or update unit tests and integration tests for any new logic added or modified.
- ✅ Ensure each controller and service method is covered by tests, unless explicitly excluded.
- 🚫 Do not include files from the `/Migrations/` folder in code coverage reports (exclude by file path or folder name).


------
https://chatgpt.com/codex/tasks/task_e_6888e45a4748832b89febf3f7a2a0141