### PR TITLE
Add bank account earnings report endpoint

### DIFF
--- a/Atlas.Api.IntegrationTests/ReportsApiTests.cs
+++ b/Atlas.Api.IntegrationTests/ReportsApiTests.cs
@@ -1,6 +1,7 @@
 using Atlas.Api.Data;
 using Atlas.Api.Models;
 using Microsoft.Extensions.DependencyInjection;
+using Atlas.Api.Models.Reports;
 
 namespace Atlas.Api.IntegrationTests;
 
@@ -27,6 +28,27 @@ public class ReportsApiTests : IntegrationTestBase
         await db.SaveChangesAsync();
     }
 
+    private static async Task SeedBankAccountDataAsync(AppDbContext db)
+    {
+        var property = await DataSeeder.SeedPropertyAsync(db);
+        var listing = await DataSeeder.SeedListingAsync(db, property);
+        var guest = await DataSeeder.SeedGuestAsync(db);
+        var account = await DataSeeder.SeedBankAccountAsync(db);
+        db.Bookings.Add(new Booking
+        {
+            ListingId = listing.Id,
+            GuestId = guest.Id,
+            BankAccountId = account.Id,
+            CheckinDate = new DateTime(2025, 5, 10),
+            CheckoutDate = new DateTime(2025, 5, 12),
+            BookingSource = "airbnb",
+            AmountReceived = 400,
+            Notes = string.Empty,
+            PaymentStatus = "Paid"
+        });
+        await db.SaveChangesAsync();
+    }
+
     [Fact]
     public async Task GetCalendarEarnings_ReturnsOk()
     {
@@ -40,5 +62,20 @@ public class ReportsApiTests : IntegrationTestBase
         var dict = await response.Content.ReadFromJsonAsync<Dictionary<string, decimal>>();
         Assert.NotNull(dict);
         Assert.Equal(2, dict!.Count);
+    }
+
+    [Fact]
+    public async Task GetBankAccountEarnings_ReturnsOk()
+    {
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        await SeedBankAccountDataAsync(db);
+
+        var response = await Client.GetAsync("/api/reports/bank-account-earnings");
+        Assert.Equal(System.Net.HttpStatusCode.OK, response.StatusCode);
+
+        var data = await response.Content.ReadFromJsonAsync<List<BankAccountEarnings>>();
+        Assert.NotNull(data);
+        Assert.Single(data!);
     }
 }

--- a/Atlas.Api.Tests/ReportsControllerTests.cs
+++ b/Atlas.Api.Tests/ReportsControllerTests.cs
@@ -1,9 +1,11 @@
 using Atlas.Api.Controllers;
 using Atlas.Api.Data;
 using Atlas.Api.Models;
+using Atlas.Api.Models.Reports;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
+using System.Linq;
 
 namespace Atlas.Api.Tests;
 
@@ -94,5 +96,123 @@ public class ReportsControllerTests
         Assert.Equal(2, dict.Count);
         Assert.Equal(100, dict["2025-07-10"]);
         Assert.Equal(100, dict["2025-07-11"]);
+    }
+
+    [Fact]
+    public async Task GetBankAccountEarnings_IncludesValidBookings()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(nameof(GetBankAccountEarnings_IncludesValidBookings))
+            .Options;
+        using var context = new AppDbContext(options);
+        var account = new BankAccount { Id = 1, BankName = "Bank", AccountNumber = "0000861", IFSC = "IFSC", AccountType = "Savings" };
+        context.BankAccounts.Add(account);
+        context.Bookings.Add(new Booking
+        {
+            ListingId = 1,
+            GuestId = 1,
+            BankAccountId = 1,
+            CheckinDate = new DateTime(2025, 4, 1),
+            CheckoutDate = new DateTime(2025, 4, 2),
+            BookingSource = "airbnb",
+            AmountReceived = 100,
+            Notes = string.Empty,
+            PaymentStatus = "Paid"
+        });
+        await context.SaveChangesAsync();
+
+        var controller = new ReportsController(context, NullLogger<ReportsController>.Instance);
+        var result = await controller.GetBankAccountEarnings();
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var list = Assert.IsAssignableFrom<IEnumerable<BankAccountEarnings>>(ok.Value).ToList();
+        Assert.Single(list);
+        Assert.Equal(100, list[0].AmountReceived);
+        Assert.Equal("Bank - 0861", list[0].AccountDisplay);
+    }
+
+    [Fact]
+    public async Task GetBankAccountEarnings_ExcludesOutsideRange()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(nameof(GetBankAccountEarnings_ExcludesOutsideRange))
+            .Options;
+        using var context = new AppDbContext(options);
+        context.BankAccounts.Add(new BankAccount { Id = 1, BankName = "Bank", AccountNumber = "123456", IFSC = "I", AccountType = "S" });
+        context.Bookings.Add(new Booking
+        {
+            ListingId = 1,
+            GuestId = 1,
+            BankAccountId = 1,
+            CheckinDate = new DateTime(2026, 4, 1),
+            CheckoutDate = new DateTime(2026, 4, 2),
+            BookingSource = "airbnb",
+            AmountReceived = 100,
+            Notes = string.Empty,
+            PaymentStatus = "Paid"
+        });
+        await context.SaveChangesAsync();
+
+        var controller = new ReportsController(context, NullLogger<ReportsController>.Instance);
+        var result = await controller.GetBankAccountEarnings();
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var list = Assert.IsAssignableFrom<IEnumerable<BankAccountEarnings>>(ok.Value).ToList();
+        Assert.Empty(list);
+    }
+
+    [Fact]
+    public async Task GetBankAccountEarnings_ReturnsEmpty_WhenNoBookings()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(nameof(GetBankAccountEarnings_ReturnsEmpty_WhenNoBookings))
+            .Options;
+        using var context = new AppDbContext(options);
+        var controller = new ReportsController(context, NullLogger<ReportsController>.Instance);
+        var result = await controller.GetBankAccountEarnings();
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var list = Assert.IsAssignableFrom<IEnumerable<BankAccountEarnings>>(ok.Value);
+        Assert.Empty(list);
+    }
+
+    [Fact]
+    public async Task GetBankAccountEarnings_AggregatesByAccount()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(nameof(GetBankAccountEarnings_AggregatesByAccount))
+            .Options;
+        using var context = new AppDbContext(options);
+        context.BankAccounts.Add(new BankAccount { Id = 1, BankName = "Bank", AccountNumber = "99993290", IFSC = "I", AccountType = "S" });
+        context.Bookings.AddRange(
+            new Booking
+            {
+                ListingId = 1,
+                GuestId = 1,
+                BankAccountId = 1,
+                CheckinDate = new DateTime(2025, 5, 1),
+                CheckoutDate = new DateTime(2025, 5, 2),
+                BookingSource = "airbnb",
+                AmountReceived = 200,
+                Notes = string.Empty,
+                PaymentStatus = "Paid"
+            },
+            new Booking
+            {
+                ListingId = 1,
+                GuestId = 1,
+                BankAccountId = 1,
+                CheckinDate = new DateTime(2025, 5, 3),
+                CheckoutDate = new DateTime(2025, 5, 4),
+                BookingSource = "airbnb",
+                AmountReceived = 300,
+                Notes = string.Empty,
+                PaymentStatus = "Paid"
+            });
+        await context.SaveChangesAsync();
+
+        var controller = new ReportsController(context, NullLogger<ReportsController>.Instance);
+        var result = await controller.GetBankAccountEarnings();
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var list = Assert.IsAssignableFrom<IEnumerable<BankAccountEarnings>>(ok.Value).ToList();
+        Assert.Single(list);
+        Assert.Equal(500, list[0].AmountReceived);
     }
 }

--- a/Atlas.Api/Models/Reports/BankAccountEarnings.cs
+++ b/Atlas.Api/Models/Reports/BankAccountEarnings.cs
@@ -1,0 +1,9 @@
+namespace Atlas.Api.Models.Reports
+{
+    public class BankAccountEarnings
+    {
+        public required string Bank { get; set; } = string.Empty;
+        public required string AccountDisplay { get; set; } = string.Empty;
+        public decimal AmountReceived { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- add `BankAccountEarnings` model
- implement `GET /api/reports/bank-account-earnings` endpoint
- add unit tests for the new aggregation logic
- add integration test for the endpoint

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not installed)*

🔁 IMPORTANT: Ensure environment-specific behavior is correctly applied:
- ✅ Use `LocalDb` for integration tests, and SQL Server for production.
- ✅ Use test connection strings for integration tests; use Azure/App Service connection strings in production.
- ✅ Apply `DeleteBehavior.Cascade` in integration tests for cleanup; use `DeleteBehavior.Restrict` in production to prevent data loss.
- ✅ Seed minimal or mock data inline for tests; avoid seeding production data unless explicitly instructed.
- ✅ Wrap integration test logic in transactions with rollback for isolation; avoid transactions for production logic.
🧪 TEST COVERAGE ENFORCEMENT:
- ✅ Add or update **unit tests** and **integration tests** for any new logic added or modified.
- ✅ Ensure each controller and service method is **covered by tests**, unless explicitly excluded.
- 🚫 Do not include files from the `/Migrations/` folder in code coverage reports (exclude by file path or folder name).

------
https://chatgpt.com/codex/tasks/task_e_6888eb946c00832b96e8ccb4ff31adc6