### PR TITLE
Return zero-earning bank accounts

### DIFF
--- a/Atlas.Api.IntegrationTests/ReportsApiTests.cs
+++ b/Atlas.Api.IntegrationTests/ReportsApiTests.cs
@@ -77,5 +77,22 @@ public class ReportsApiTests : IntegrationTestBase
         var data = await response.Content.ReadFromJsonAsync<List<BankAccountEarnings>>();
         Assert.NotNull(data);
         Assert.Single(data!);
+        Assert.Equal(400, data![0].AmountReceived);
+    }
+
+    [Fact]
+    public async Task GetBankAccountEarnings_ReturnsZeroForAccountWithoutBookings()
+    {
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        await DataSeeder.SeedBankAccountAsync(db);
+
+        var response = await Client.GetAsync("/api/reports/bank-account-earnings");
+        Assert.Equal(System.Net.HttpStatusCode.OK, response.StatusCode);
+
+        var data = await response.Content.ReadFromJsonAsync<List<BankAccountEarnings>>();
+        Assert.NotNull(data);
+        Assert.Single(data!);
+        Assert.Equal(0, data![0].AmountReceived);
     }
 }

--- a/Atlas.Api.Tests/ReportsControllerTests.cs
+++ b/Atlas.Api.Tests/ReportsControllerTests.cs
@@ -156,7 +156,26 @@ public class ReportsControllerTests
         var result = await controller.GetBankAccountEarnings();
         var ok = Assert.IsType<OkObjectResult>(result.Result);
         var list = Assert.IsAssignableFrom<IEnumerable<BankAccountEarnings>>(ok.Value).ToList();
-        Assert.Empty(list);
+        Assert.Single(list);
+        Assert.Equal(0, list[0].AmountReceived);
+    }
+
+    [Fact]
+    public async Task GetBankAccountEarnings_ReturnsZero_WhenAccountHasNoBookings()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(nameof(GetBankAccountEarnings_ReturnsZero_WhenAccountHasNoBookings))
+            .Options;
+        using var context = new AppDbContext(options);
+        context.BankAccounts.Add(new BankAccount { Id = 1, BankName = "Bank", AccountNumber = "123456", IFSC = "I", AccountType = "S" });
+        await context.SaveChangesAsync();
+
+        var controller = new ReportsController(context, NullLogger<ReportsController>.Instance);
+        var result = await controller.GetBankAccountEarnings();
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var list = Assert.IsAssignableFrom<IEnumerable<BankAccountEarnings>>(ok.Value).ToList();
+        Assert.Single(list);
+        Assert.Equal(0, list[0].AmountReceived);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- return all bank accounts in GetBankAccountEarnings
- show zero earnings if no matching bookings
- test for zero amounts in controller and API tests

## Testing
- `dotnet test Atlas.Api.Tests/Atlas.Api.Tests.csproj --no-build -v minimal`
- `dotnet test Atlas.Api.IntegrationTests/Atlas.Api.IntegrationTests.csproj --no-build -v minimal` *(fails: LocalDB not supported)*

------
https://chatgpt.com/codex/tasks/task_e_6888f02a8670832ba38ba7ba5bb0ffcb