### PR TITLE
Return booking source in calendar earnings

### DIFF
--- a/Atlas.Api.IntegrationTests/ReportsApiTests.cs
+++ b/Atlas.Api.IntegrationTests/ReportsApiTests.cs
@@ -59,9 +59,9 @@ public class ReportsApiTests : IntegrationTestBase
         var response = await Client.GetAsync("/api/reports/calendar-earnings?listingId=1&month=2025-07");
         Assert.Equal(System.Net.HttpStatusCode.OK, response.StatusCode);
 
-        var dict = await response.Content.ReadFromJsonAsync<Dictionary<string, decimal>>();
-        Assert.NotNull(dict);
-        Assert.Equal(2, dict!.Count);
+        var list = await response.Content.ReadFromJsonAsync<List<DailySourceEarnings>>();
+        Assert.NotNull(list);
+        Assert.Equal(2, list!.Count);
     }
 
     [Fact]

--- a/Atlas.Api.Tests/ReportsControllerTests.cs
+++ b/Atlas.Api.Tests/ReportsControllerTests.cs
@@ -34,11 +34,15 @@ public class ReportsControllerTests
         var controller = new ReportsController(context, NullLogger<ReportsController>.Instance);
         var result = await controller.GetCalendarEarnings(1, "2025-07");
         var ok = Assert.IsType<OkObjectResult>(result.Result);
-        var dict = Assert.IsType<Dictionary<string, decimal>>(ok.Value);
-        Assert.Equal(3, dict.Count);
-        Assert.Equal(100, dict["2025-07-05"]);
-        Assert.Equal(100, dict["2025-07-06"]);
-        Assert.Equal(100, dict["2025-07-07"]);
+        var list = Assert.IsAssignableFrom<IEnumerable<DailySourceEarnings>>(ok.Value).OrderBy(x => x.Date).ToList();
+        Assert.Equal(3, list.Count);
+        Assert.All(list, item => Assert.Equal("airbnb", item.Source));
+        Assert.Equal(new DateTime(2025,7,5), list[0].Date);
+        Assert.Equal(100, list[0].Amount);
+        Assert.Equal(new DateTime(2025,7,6), list[1].Date);
+        Assert.Equal(100, list[1].Amount);
+        Assert.Equal(new DateTime(2025,7,7), list[2].Date);
+        Assert.Equal(100, list[2].Amount);
     }
 
     [Fact]
@@ -64,9 +68,10 @@ public class ReportsControllerTests
         var controller = new ReportsController(context, NullLogger<ReportsController>.Instance);
         var result = await controller.GetCalendarEarnings(1, "2025-07");
         var ok = Assert.IsType<OkObjectResult>(result.Result);
-        var dict = Assert.IsType<Dictionary<string, decimal>>(ok.Value);
-        Assert.Single(dict);
-        Assert.Equal(100, dict["2025-07-01"]);
+        var list = Assert.IsAssignableFrom<IEnumerable<DailySourceEarnings>>(ok.Value).ToList();
+        Assert.Single(list);
+        Assert.Equal(new DateTime(2025,7,1), list[0].Date);
+        Assert.Equal(100, list[0].Amount);
     }
 
     [Fact]
@@ -92,10 +97,12 @@ public class ReportsControllerTests
         var controller = new ReportsController(context, NullLogger<ReportsController>.Instance);
         var result = await controller.GetCalendarEarnings(1, "2025-07");
         var ok = Assert.IsType<OkObjectResult>(result.Result);
-        var dict = Assert.IsType<Dictionary<string, decimal>>(ok.Value);
-        Assert.Equal(2, dict.Count);
-        Assert.Equal(100, dict["2025-07-10"]);
-        Assert.Equal(100, dict["2025-07-11"]);
+        var list = Assert.IsAssignableFrom<IEnumerable<DailySourceEarnings>>(ok.Value).OrderBy(x => x.Date).ToList();
+        Assert.Equal(2, list.Count);
+        Assert.Equal(new DateTime(2025,7,10), list[0].Date);
+        Assert.Equal(100, list[0].Amount);
+        Assert.Equal(new DateTime(2025,7,11), list[1].Date);
+        Assert.Equal(100, list[1].Amount);
     }
 
     [Fact]

--- a/Atlas.Api/Models/Reports/DailySourceEarnings.cs
+++ b/Atlas.Api/Models/Reports/DailySourceEarnings.cs
@@ -1,0 +1,9 @@
+namespace Atlas.Api.Models.Reports
+{
+    public class DailySourceEarnings
+    {
+        public DateTime Date { get; set; }
+        public required string Source { get; set; } = string.Empty;
+        public decimal Amount { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- expose source in the calendar earnings report
- add `DailySourceEarnings` report model
- update unit and integration tests for new response format

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688991fdcd24832ba12ec955780352be