### PR TITLE
Add booking source to calendar earnings

### DIFF
--- a/Atlas.Api.IntegrationTests/ReportsApiTests.cs
+++ b/Atlas.Api.IntegrationTests/ReportsApiTests.cs
@@ -59,9 +59,9 @@ public class ReportsApiTests : IntegrationTestBase
         var response = await Client.GetAsync("/api/reports/calendar-earnings?listingId=1&month=2025-07");
         Assert.Equal(System.Net.HttpStatusCode.OK, response.StatusCode);
 
-        var dict = await response.Content.ReadFromJsonAsync<Dictionary<string, decimal>>();
-        Assert.NotNull(dict);
-        Assert.Equal(2, dict!.Count);
+        var list = await response.Content.ReadFromJsonAsync<List<DailySourceEarnings>>();
+        Assert.NotNull(list);
+        Assert.Equal(2, list!.Count);
     }
 
     [Fact]

--- a/Atlas.Api.Tests/ReportsControllerTests.cs
+++ b/Atlas.Api.Tests/ReportsControllerTests.cs
@@ -34,11 +34,12 @@ public class ReportsControllerTests
         var controller = new ReportsController(context, NullLogger<ReportsController>.Instance);
         var result = await controller.GetCalendarEarnings(1, "2025-07");
         var ok = Assert.IsType<OkObjectResult>(result.Result);
-        var dict = Assert.IsType<Dictionary<string, decimal>>(ok.Value);
-        Assert.Equal(3, dict.Count);
-        Assert.Equal(100, dict["2025-07-05"]);
-        Assert.Equal(100, dict["2025-07-06"]);
-        Assert.Equal(100, dict["2025-07-07"]);
+        var list = Assert.IsAssignableFrom<IEnumerable<DailySourceEarnings>>(ok.Value).ToList();
+        Assert.Equal(3, list.Count);
+        Assert.All(list, i => Assert.Equal("airbnb", i.Source));
+        Assert.Contains(list, i => i.Date == "2025-07-05" && i.Amount == 100);
+        Assert.Contains(list, i => i.Date == "2025-07-06" && i.Amount == 100);
+        Assert.Contains(list, i => i.Date == "2025-07-07" && i.Amount == 100);
     }
 
     [Fact]
@@ -64,9 +65,12 @@ public class ReportsControllerTests
         var controller = new ReportsController(context, NullLogger<ReportsController>.Instance);
         var result = await controller.GetCalendarEarnings(1, "2025-07");
         var ok = Assert.IsType<OkObjectResult>(result.Result);
-        var dict = Assert.IsType<Dictionary<string, decimal>>(ok.Value);
-        Assert.Single(dict);
-        Assert.Equal(100, dict["2025-07-01"]);
+        var list = Assert.IsAssignableFrom<IEnumerable<DailySourceEarnings>>(ok.Value).ToList();
+        Assert.Single(list);
+        var entry = list.Single();
+        Assert.Equal("2025-07-01", entry.Date);
+        Assert.Equal(100, entry.Amount);
+        Assert.Equal("airbnb", entry.Source);
     }
 
     [Fact]
@@ -92,10 +96,10 @@ public class ReportsControllerTests
         var controller = new ReportsController(context, NullLogger<ReportsController>.Instance);
         var result = await controller.GetCalendarEarnings(1, "2025-07");
         var ok = Assert.IsType<OkObjectResult>(result.Result);
-        var dict = Assert.IsType<Dictionary<string, decimal>>(ok.Value);
-        Assert.Equal(2, dict.Count);
-        Assert.Equal(100, dict["2025-07-10"]);
-        Assert.Equal(100, dict["2025-07-11"]);
+        var list = Assert.IsAssignableFrom<IEnumerable<DailySourceEarnings>>(ok.Value).ToList();
+        Assert.Equal(2, list.Count);
+        Assert.Contains(list, i => i.Date == "2025-07-10" && i.Amount == 100 && i.Source == "airbnb");
+        Assert.Contains(list, i => i.Date == "2025-07-11" && i.Amount == 100 && i.Source == "airbnb");
     }
 
     [Fact]

--- a/Atlas.Api/Models/Reports/DailySourceEarnings.cs
+++ b/Atlas.Api/Models/Reports/DailySourceEarnings.cs
@@ -1,0 +1,9 @@
+namespace Atlas.Api.Models.Reports
+{
+    public class DailySourceEarnings
+    {
+        public required string Date { get; set; } = string.Empty;
+        public required string Source { get; set; } = string.Empty;
+        public decimal Amount { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- create a new **DailySourceEarnings** report model
- modify `GetCalendarEarnings` endpoint to return a list with booking source info
- update unit and integration tests for the new endpoint format

## Testing
- `dotnet test Atlas.Api.Tests/Atlas.Api.Tests.csproj`
- `dotnet test Atlas.Api.IntegrationTests/Atlas.Api.IntegrationTests.csproj` *(fails: SQL Server not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889963c34ec832bb312d37d2d8fd3ee