### PR TITLE
refactor: derive gross from net and fees

### DIFF
--- a/Atlas.Api.Tests/AdminReportsControllerTests.cs
+++ b/Atlas.Api.Tests/AdminReportsControllerTests.cs
@@ -10,7 +10,7 @@ using System.Linq;
 public class AdminReportsControllerTests
 {
     [Fact]
-    public async Task GetMonthlyEarnings_ComputesGrossNetAndFees()
+    public async Task GetMonthlyEarnings_ComputesNetAndFees()
     {
         var options = new DbContextOptionsBuilder<AppDbContext>()
             .UseInMemoryDatabase(databaseName: "MonthlyEarningsTest")
@@ -40,14 +40,15 @@ public class AdminReportsControllerTests
         var first = list.Single(x => x.Month == key0);
         Assert.Equal(100, first.TotalNet);
         Assert.Equal(100 * 0.16m, first.TotalFees);
-        Assert.Equal(100 + 100 * 0.16m, first.TotalGross);
 
         var second = list.Single(x => x.Month == key1);
         var net = 200 + 300;
         var fees = 200 * 0.15m + 300 * 0.18m;
         Assert.Equal(net, second.TotalNet);
         Assert.Equal(fees, second.TotalFees);
-        Assert.Equal(net + fees, second.TotalGross);
+        // For backward compatibility ensure TotalGross equals TotalNet + TotalFees
+        Assert.Equal(first.TotalNet + first.TotalFees, first.TotalGross);
+        Assert.Equal(second.TotalNet + second.TotalFees, second.TotalGross);
     }
 
     [Fact]

--- a/Atlas.Api/Controllers/AdminReportsController.cs
+++ b/Atlas.Api/Controllers/AdminReportsController.cs
@@ -131,8 +131,7 @@ namespace Atlas.Api.Controllers
                 {
                     Month = k,
                     TotalNet = grouped.TryGetValue(k, out var data) ? data.TotalNet : 0,
-                    TotalFees = grouped.TryGetValue(k, out data) ? data.TotalFees : 0,
-                    TotalGross = grouped.TryGetValue(k, out data) ? data.TotalNet + data.TotalFees : 0
+                    TotalFees = grouped.TryGetValue(k, out data) ? data.TotalFees : 0
                 }).ToList();
 
                 return Ok(result);
@@ -187,8 +186,7 @@ namespace Atlas.Api.Controllers
                 {
                     Month = k,
                     TotalNet = grouped.TryGetValue(k, out var data) ? data.TotalNet : 0,
-                    TotalFees = grouped.TryGetValue(k, out data) ? data.TotalFees : 0,
-                    TotalGross = grouped.TryGetValue(k, out data) ? data.TotalNet + data.TotalFees : 0
+                    TotalFees = grouped.TryGetValue(k, out data) ? data.TotalFees : 0
                 }).ToList();
 
                 return Ok(result);

--- a/Atlas.Api/Models/Reports/MonthlyEarningsSummary.cs
+++ b/Atlas.Api/Models/Reports/MonthlyEarningsSummary.cs
@@ -1,10 +1,15 @@
+using System;
+
 namespace Atlas.Api.Models.Reports
 {
     public class MonthlyEarningsSummary
     {
         public required string Month { get; set; } = string.Empty;
-        public decimal TotalGross { get; set; }
         public decimal TotalFees { get; set; }
         public decimal TotalNet { get; set; }
+
+        // Deprecated: use TotalNet + TotalFees instead
+        [Obsolete("Use TotalNet + TotalFees. This property will be removed in a future release.")]
+        public decimal TotalGross => TotalNet + TotalFees;
     }
 }


### PR DESCRIPTION
## Summary
- compute `TotalGross` from `TotalNet` and `TotalFees`
- stop setting `TotalGross` in `AdminReportsController`
- adjust `AdminReportsControllerTests` for computed gross

## Testing
- `dotnet test Atlas.Api.Tests/Atlas.Api.Tests.csproj`
- `dotnet test Atlas.Api.IntegrationTests/Atlas.Api.IntegrationTests.csproj` *(fails: LocalDB is not supported on this platform)*

------
https://chatgpt.com/codex/tasks/task_e_688e626b44b0832b9754af188894b365