### PR TITLE
Include same-day bookings in calendar earnings

### DIFF
--- a/Atlas.Api/Controllers/ReportsController.cs
+++ b/Atlas.Api/Controllers/ReportsController.cs
@@ -44,7 +44,18 @@ namespace Atlas.Api.Controllers
             foreach (var b in bookings)
             {
                 var nights = (b.CheckoutDate.Date - b.CheckinDate.Date).TotalDays;
-                if (nights <= 0) continue;
+                if (nights <= 0)
+                {
+                    var day = b.CheckinDate.Date;
+                    if (day >= monthStart && day < monthEnd)
+                    {
+                        var key = (day, b.BookingSource);
+                        result.TryGetValue(key, out var current);
+                        result[key] = current + b.AmountReceived;
+                    }
+                    continue;
+                }
+
                 var dailyAmount = b.AmountReceived / (decimal)nights;
                 for (var day = b.CheckinDate.Date; day < b.CheckoutDate.Date; day = day.AddDays(1))
                 {


### PR DESCRIPTION
## Summary
- handle bookings with check-in equal to check-out as one-day revenue in calendar earnings
- cover same-day booking scenario in controller and API tests

## Testing
- `dotnet test` *(integration tests fail: LocalDB is not supported on this platform)*

------
https://chatgpt.com/codex/tasks/task_e_688e6c38027c832b8424ed60de83a2df