### PR TITLE
Allow multiple calendar earnings per day

### DIFF
--- a/Atlas.Api.IntegrationTests/ReportsApiTests.cs
+++ b/Atlas.Api.IntegrationTests/ReportsApiTests.cs
@@ -78,7 +78,7 @@ public class ReportsApiTests : IntegrationTestBase
         var response = await Client.GetAsync("/api/reports/calendar-earnings?listingId=1&month=2025-07");
         Assert.Equal(System.Net.HttpStatusCode.OK, response.StatusCode);
 
-        var list = await response.Content.ReadFromJsonAsync<List<DailySourceEarnings>>();
+        var list = await response.Content.ReadFromJsonAsync<List<CalendarEarningEntry>>();
         Assert.NotNull(list);
         Assert.Equal(2, list!.Count);
     }
@@ -93,13 +93,59 @@ public class ReportsApiTests : IntegrationTestBase
         var response = await Client.GetAsync("/api/reports/calendar-earnings?listingId=1&month=2025-06");
         Assert.Equal(System.Net.HttpStatusCode.OK, response.StatusCode);
 
-        var list = await response.Content.ReadFromJsonAsync<List<DailySourceEarnings>>();
+        var list = await response.Content.ReadFromJsonAsync<List<CalendarEarningEntry>>();
         Assert.NotNull(list);
         Assert.Single(list!);
         var entry = list![0];
-        Assert.Equal("2025-06-18", entry.Date);
-        Assert.Equal("direct", entry.Source);
-        Assert.Equal(2650.88m, entry.Amount);
+        Assert.Equal(new DateTime(2025, 6, 18), entry.Date);
+        Assert.Single(entry.Earnings);
+        Assert.Equal("direct", entry.Earnings[0].Source);
+        Assert.Equal(2650.88m, entry.Earnings[0].Amount);
+        Assert.Equal(2650.88m, entry.Total);
+    }
+
+    [Fact]
+    public async Task GetCalendarEarnings_AllowsMultipleEntriesSameSource()
+    {
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var property = await DataSeeder.SeedPropertyAsync(db);
+        var listing = await DataSeeder.SeedListingAsync(db, property);
+        var guest = await DataSeeder.SeedGuestAsync(db);
+        db.Bookings.AddRange(
+            new Booking
+            {
+                ListingId = listing.Id,
+                GuestId = guest.Id,
+                CheckinDate = new DateTime(2025, 7, 15),
+                CheckoutDate = new DateTime(2025, 7, 15),
+                BookingSource = "walk-in",
+                AmountReceived = 100,
+                Notes = string.Empty,
+                PaymentStatus = "Paid"
+            },
+            new Booking
+            {
+                ListingId = listing.Id,
+                GuestId = guest.Id,
+                CheckinDate = new DateTime(2025, 7, 15),
+                CheckoutDate = new DateTime(2025, 7, 15),
+                BookingSource = "walk-in",
+                AmountReceived = 150,
+                Notes = string.Empty,
+                PaymentStatus = "Paid"
+            });
+        await db.SaveChangesAsync();
+
+        var response = await Client.GetAsync("/api/reports/calendar-earnings?listingId=1&month=2025-07");
+        Assert.Equal(System.Net.HttpStatusCode.OK, response.StatusCode);
+
+        var list = await response.Content.ReadFromJsonAsync<List<CalendarEarningEntry>>();
+        Assert.NotNull(list);
+        Assert.Single(list!);
+        var entry = list![0];
+        Assert.Equal(2, entry.Earnings.Count);
+        Assert.Equal(250, entry.Total);
     }
 
     [Fact]

--- a/Atlas.Api/Models/Reports/DailySourceEarnings.cs
+++ b/Atlas.Api/Models/Reports/DailySourceEarnings.cs
@@ -1,9 +1,18 @@
-namespace Atlas.Api.Models.Reports
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Atlas.Api.Models.Reports;
+
+public class CalendarEarningEntry
 {
-    public class DailySourceEarnings
-    {
-        public required string Date { get; set; } = string.Empty;
-        public required string Source { get; set; } = string.Empty;
-        public decimal Amount { get; set; }
-    }
+    public DateTime Date { get; set; }
+    public List<BookingEarningDetail> Earnings { get; set; } = new();
+    public decimal Total => Earnings.Sum(e => e.Amount);
+}
+
+public class BookingEarningDetail
+{
+    public required string Source { get; set; }
+    public decimal Amount { get; set; }
 }


### PR DESCRIPTION
## Summary
- allow multiple booking earnings per day and compute totals for calendar view
- clamp calendar earnings to six-week range starting on Sunday
- cover new calendar-earnings scenarios in unit and integration tests

## Testing
- `dotnet test` *(fails: LocalDB is not supported on this platform)*


------
https://chatgpt.com/codex/tasks/task_e_688fc07ecb80832ba9142fa161ccafce