### PR TITLE
feat: include booking details in calendar earnings

### DIFF
--- a/Atlas.Api.IntegrationTests/ReportsApiTests.cs
+++ b/Atlas.Api.IntegrationTests/ReportsApiTests.cs
@@ -81,6 +81,8 @@ public class ReportsApiTests : IntegrationTestBase
         var list = await response.Content.ReadFromJsonAsync<List<CalendarEarningEntry>>();
         Assert.NotNull(list);
         Assert.Equal(2, list!.Count);
+        Assert.True(list![0].Earnings[0].BookingId > 0);
+        Assert.False(string.IsNullOrWhiteSpace(list![0].Earnings[0].GuestName));
     }
 
     [Fact]
@@ -99,8 +101,11 @@ public class ReportsApiTests : IntegrationTestBase
         var entry = list![0];
         Assert.Equal(new DateTime(2025, 6, 18), entry.Date);
         Assert.Single(entry.Earnings);
-        Assert.Equal("direct", entry.Earnings[0].Source);
-        Assert.Equal(2650.88m, entry.Earnings[0].Amount);
+        var earning = entry.Earnings[0];
+        Assert.Equal("direct", earning.Source);
+        Assert.Equal(2650.88m, earning.Amount);
+        Assert.True(earning.BookingId > 0);
+        Assert.Equal("Guest", earning.GuestName);
         Assert.Equal(2650.88m, entry.Total);
     }
 
@@ -146,6 +151,8 @@ public class ReportsApiTests : IntegrationTestBase
         var entry = list![0];
         Assert.Equal(2, entry.Earnings.Count);
         Assert.Equal(250, entry.Total);
+        Assert.NotEqual(entry.Earnings[0].BookingId, entry.Earnings[1].BookingId);
+        Assert.All(entry.Earnings, e => Assert.Equal("Guest", e.GuestName));
     }
 
     [Fact]

--- a/Atlas.Api.Tests/ReportsControllerTests.cs
+++ b/Atlas.Api.Tests/ReportsControllerTests.cs
@@ -42,6 +42,8 @@ public class ReportsControllerTests
         var detail = entry.Earnings.Single();
         Assert.Equal("direct", detail.Source);
         Assert.Equal(2650.88m, detail.Amount);
+        Assert.Equal(1, detail.BookingId);
+        Assert.Equal("Unknown Guest", detail.GuestName);
         Assert.Equal(2650.88m, entry.Total);
     }
 
@@ -72,6 +74,8 @@ public class ReportsControllerTests
         Assert.Equal(3, list.Count);
         Assert.All(list, i => Assert.Equal(1, i.Earnings.Count));
         Assert.All(list, i => Assert.Equal("airbnb", i.Earnings[0].Source));
+        Assert.All(list, i => Assert.Equal(1, i.Earnings[0].BookingId));
+        Assert.All(list, i => Assert.Equal("Unknown Guest", i.Earnings[0].GuestName));
         Assert.Contains(list, i => i.Date == new DateTime(2025, 7, 5) && i.Earnings[0].Amount == 100);
         Assert.Contains(list, i => i.Date == new DateTime(2025, 7, 6) && i.Earnings[0].Amount == 100);
         Assert.Contains(list, i => i.Date == new DateTime(2025, 7, 7) && i.Earnings[0].Amount == 100);
@@ -120,6 +124,8 @@ public class ReportsControllerTests
         Assert.All(entry.Earnings, e => Assert.Equal("walk-in", e.Source));
         Assert.Contains(entry.Earnings, e => e.Amount == 100);
         Assert.Contains(entry.Earnings, e => e.Amount == 150);
+        Assert.Equal(2, entry.Earnings.Select(e => e.BookingId).Distinct().Count());
+        Assert.All(entry.Earnings, e => Assert.Equal("Unknown Guest", e.GuestName));
         Assert.Equal(250, entry.Total);
     }
 

--- a/Atlas.Api/Controllers/ReportsController.cs
+++ b/Atlas.Api/Controllers/ReportsController.cs
@@ -37,10 +37,19 @@ namespace Atlas.Api.Controllers
             var calendarEnd = calendarStart.AddDays(42);
 
             var bookings = await _context.Bookings
+                .Include(b => b.Guest)
                 .Where(b => b.ListingId == listingId &&
                             b.CheckinDate < calendarEnd &&
                             b.CheckoutDate > calendarStart)
-                .Select(b => new { b.CheckinDate, b.CheckoutDate, b.AmountReceived, b.BookingSource })
+                .Select(b => new
+                {
+                    b.Id,
+                    b.CheckinDate,
+                    b.CheckoutDate,
+                    b.AmountReceived,
+                    b.BookingSource,
+                    GuestName = b.Guest != null ? b.Guest.Name : null
+                })
                 .ToListAsync();
 
             var result = new Dictionary<DateTime, List<BookingEarningDetail>>();
@@ -59,7 +68,13 @@ namespace Atlas.Api.Controllers
                             list = new List<BookingEarningDetail>();
                             result[day] = list;
                         }
-                        list.Add(new BookingEarningDetail { Source = b.BookingSource, Amount = Math.Round(b.AmountReceived, 2) });
+                        list.Add(new BookingEarningDetail
+                        {
+                            BookingId = b.Id,
+                            GuestName = b.GuestName ?? "Unknown Guest",
+                            Source = b.BookingSource,
+                            Amount = Math.Round(b.AmountReceived, 2)
+                        });
                     }
                     continue;
                 }
@@ -74,7 +89,13 @@ namespace Atlas.Api.Controllers
                             list = new List<BookingEarningDetail>();
                             result[day] = list;
                         }
-                        list.Add(new BookingEarningDetail { Source = b.BookingSource, Amount = dailyAmount });
+                        list.Add(new BookingEarningDetail
+                        {
+                            BookingId = b.Id,
+                            GuestName = b.GuestName ?? "Unknown Guest",
+                            Source = b.BookingSource,
+                            Amount = dailyAmount
+                        });
                     }
                 }
             }

--- a/Atlas.Api/Models/Reports/DailySourceEarnings.cs
+++ b/Atlas.Api/Models/Reports/DailySourceEarnings.cs
@@ -13,6 +13,8 @@ public class CalendarEarningEntry
 
 public class BookingEarningDetail
 {
+    public int BookingId { get; set; }
+    public required string GuestName { get; set; }
     public required string Source { get; set; }
     public decimal Amount { get; set; }
 }


### PR DESCRIPTION
## Summary
- extend `BookingEarningDetail` to expose `BookingId` and `GuestName`
- populate booking identifiers and guest names in `GetCalendarEarnings`
- validate new fields in calendar earnings tests

## Testing
- `dotnet test` *(fails: Microsoft.Data.SqlClient.SqlException: A network-related or instance-specific error occurred while establishing a connection to SQL Server)*

------
https://chatgpt.com/codex/tasks/task_e_688fcc5bbfcc832b99d03f15b077676f