### PR TITLE
feat: add guests search endpoint

### DIFF
--- a/Application/Guests/Queries/SearchGuests/SearchGuestsQueryHandler.cs
+++ b/Application/Guests/Queries/SearchGuests/SearchGuestsQueryHandler.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Linq;
+using System.Diagnostics;
+using Application.Guests.Queries.SearchGuests;
+using Atlas.Api.Data;
+using Atlas.Api.Models;
+using Infrastructure.Phone;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Application.Guests.Queries.SearchGuests;
+
+public class SearchGuestsQueryHandler
+{
+    private readonly AppDbContext _context;
+    private readonly PhoneNormalizer _phoneNormalizer;
+    private readonly ILogger<SearchGuestsQueryHandler> _logger;
+
+    public SearchGuestsQueryHandler(AppDbContext context, PhoneNormalizer phoneNormalizer, ILogger<SearchGuestsQueryHandler> logger)
+    {
+        _context = context;
+        _phoneNormalizer = phoneNormalizer;
+        _logger = logger;
+    }
+
+    public async Task<SearchGuestsResponse> Handle(SearchGuestsRequest request, CancellationToken cancellationToken)
+    {
+        var sw = Stopwatch.StartNew();
+        var q = (request.Query ?? string.Empty).Trim();
+        var digits = new string(q.Where(char.IsDigit).ToArray());
+        var isPhone = digits.Length == q.Length && digits.Length > 0;
+        var normalizedPhone = isPhone ? _phoneNormalizer.Normalize(digits) : null;
+        var lowerEmail = q.ToLowerInvariant();
+        var isEmail = q.Contains('@');
+        var page = request.Page < 1 ? 1 : request.Page;
+        var pageSize = request.PageSize;
+
+        var baseQuery = _context.Guests.AsNoTracking().AsQueryable();
+
+        if (isPhone && normalizedPhone != null)
+        {
+            baseQuery = baseQuery.Where(g => g.PhoneE164 == normalizedPhone);
+        }
+        else if (isEmail)
+        {
+            baseQuery = baseQuery.Where(g => g.Email.ToLower() == lowerEmail);
+        }
+        else
+        {
+            var lower = q.ToLowerInvariant();
+            baseQuery = baseQuery.Where(g => g.NameSearch.Contains(lower));
+        }
+
+        var ordered = baseQuery
+            .OrderByDescending(g => isPhone && g.PhoneE164 == normalizedPhone)
+            .ThenByDescending(g => isEmail && g.Email.ToLower() == lowerEmail)
+            .ThenByDescending(g => g.NameSearch.StartsWith(q.ToLowerInvariant()))
+            .ThenBy(g => g.Name);
+
+        int total;
+        if (page <= 2)
+        {
+            total = await ordered.CountAsync(cancellationToken);
+        }
+        else
+        {
+            total = Math.Min(1000, await ordered.Take(1000).CountAsync(cancellationToken));
+        }
+
+        var items = await ordered
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .Select(g => new GuestListItem(g.Id, g.Name, g.Phone, g.Email, g.PhoneE164))
+            .ToListAsync(cancellationToken);
+
+        sw.Stop();
+        _logger.LogInformation("SearchGuests {UserId} {qLen} {isPhone} {isEmail} {page} {pageSize} {resultCount} {elapsedMs}",
+            "anonymous", q.Length, isPhone, isEmail, page, pageSize, items.Count, sw.ElapsedMilliseconds);
+
+        return new SearchGuestsResponse(total, page, pageSize, items);
+    }
+}

--- a/Application/Guests/Queries/SearchGuests/SearchGuestsRequest.cs
+++ b/Application/Guests/Queries/SearchGuests/SearchGuestsRequest.cs
@@ -1,0 +1,3 @@
+namespace Application.Guests.Queries.SearchGuests;
+
+public sealed record SearchGuestsRequest(string Query, int Page = 1, int PageSize = 10, string? Fields = null);

--- a/Application/Guests/Queries/SearchGuests/SearchGuestsResponse.cs
+++ b/Application/Guests/Queries/SearchGuests/SearchGuestsResponse.cs
@@ -1,0 +1,4 @@
+namespace Application.Guests.Queries.SearchGuests;
+
+public sealed record SearchGuestsResponse(int Total, int Page, int PageSize, IReadOnlyList<GuestListItem> Items);
+public sealed record GuestListItem(int Id, string Name, string? Phone, string? Email, string? PhoneE164);

--- a/Atlas.Api.IntegrationTests/CustomWebApplicationFactory.cs
+++ b/Atlas.Api.IntegrationTests/CustomWebApplicationFactory.cs
@@ -23,6 +23,7 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>
             Environment.GetEnvironmentVariable("Atlas_TestDb") ??
             $"Server=(localdb)\\MSSQLLocalDB;Database={dbName};Trusted_Connection=True;";
 
+        Environment.SetEnvironmentVariable("JWT_KEY", "testkey123");
         Environment.SetEnvironmentVariable("DEFAULT_CONNECTION", connectionString);
 
         builder.ConfigureServices(services =>

--- a/Atlas.Api.IntegrationTests/DataSeeder.cs
+++ b/Atlas.Api.IntegrationTests/DataSeeder.cs
@@ -1,5 +1,6 @@
 using Atlas.Api.Data;
 using Atlas.Api.Models;
+using Infrastructure.Phone;
 
 namespace Atlas.Api.IntegrationTests;
 
@@ -43,7 +44,10 @@ public static class DataSeeder
 
     public static async Task<Guest> SeedGuestAsync(AppDbContext db)
     {
+        var phoneNorm = new PhoneNormalizer();
         var guest = new Guest { Name = "Guest", Phone = "1", Email = "g@example.com", IdProofUrl = "N/A" };
+        guest.NameSearch = guest.Name.ToLowerInvariant();
+        guest.PhoneE164 = phoneNorm.Normalize(guest.Phone);
         db.Guests.Add(guest);
         await db.SaveChangesAsync();
         return guest;

--- a/Atlas.Api.IntegrationTests/GuestsSearchApiTests.cs
+++ b/Atlas.Api.IntegrationTests/GuestsSearchApiTests.cs
@@ -1,0 +1,109 @@
+using Atlas.Api.Data;
+using Atlas.Api.Models;
+using Application.Guests.Queries.SearchGuests;
+using Infrastructure.Phone;
+using Microsoft.Extensions.DependencyInjection;
+using System.IdentityModel.Tokens.Jwt;
+using Microsoft.IdentityModel.Tokens;
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using System.Text;
+
+namespace Atlas.Api.IntegrationTests;
+
+public class GuestsSearchApiTests : IntegrationTestBase
+{
+    public GuestsSearchApiTests(CustomWebApplicationFactory factory) : base(factory) { }
+
+    private async Task SeedGuestsAsync(int count = 200)
+    {
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var normalizer = new PhoneNormalizer();
+        for (int i = 0; i < count; i++)
+        {
+            var phone = $"990000{i:D3}";
+            var guest = new Guest { Name = $"Raj{i}", Phone = phone, Email = $"raj{i}@example.com" };
+            guest.NameSearch = guest.Name.ToLowerInvariant();
+            guest.PhoneE164 = normalizer.Normalize(phone);
+            db.Guests.Add(guest);
+        }
+        await db.SaveChangesAsync();
+    }
+
+    private void Authenticate()
+    {
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes("testkey123"));
+        var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+        var token = new JwtSecurityToken(claims: new[] { new Claim("sub", "test") }, expires: DateTime.UtcNow.AddMinutes(5), signingCredentials: creds);
+        var jwt = new JwtSecurityTokenHandler().WriteToken(token);
+        Client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", jwt);
+    }
+
+    [Fact]
+    public async Task Search_ByPhone_ReturnsExact()
+    {
+        await SeedGuestsAsync();
+        Authenticate();
+        var response = await Client.GetFromJsonAsync<SearchGuestsResponse>("/api/guests/search?query=990000050");
+        Assert.Equal(1, response!.Items.Count);
+        Assert.Equal("Raj50", response.Items[0].Name);
+    }
+
+    [Fact]
+    public async Task Search_ByEmail_ReturnsExact()
+    {
+        await SeedGuestsAsync();
+        Authenticate();
+        var response = await Client.GetFromJsonAsync<SearchGuestsResponse>("/api/guests/search?query=raj10@example.com");
+        Assert.Equal("Raj10", response!.Items[0].Name);
+    }
+
+    [Fact]
+    public async Task Search_ByNamePrefix_Returns()
+    {
+        await SeedGuestsAsync();
+        Authenticate();
+        var response = await Client.GetFromJsonAsync<SearchGuestsResponse>("/api/guests/search?query=Raj1");
+        Assert.True(response!.Items.Count > 0);
+    }
+
+    [Fact]
+    public async Task Search_ByNameContains_Returns()
+    {
+        await SeedGuestsAsync();
+        Authenticate();
+        var response = await Client.GetFromJsonAsync<SearchGuestsResponse>("/api/guests/search?query=aj1");
+        Assert.True(response!.Items.Count > 0);
+    }
+
+    [Fact]
+    public async Task Search_Paging_Works()
+    {
+        await SeedGuestsAsync();
+        Authenticate();
+        var response = await Client.GetFromJsonAsync<SearchGuestsResponse>("/api/guests/search?query=Raj&page=2&pageSize=5");
+        Assert.Equal(2, response!.Page);
+        Assert.Equal(5, response.Items.Count);
+    }
+
+    [Fact]
+    public async Task Search_MinLengthValidation()
+    {
+        await SeedGuestsAsync();
+        Authenticate();
+        var resp = await Client.GetAsync("/api/guests/search?query=r");
+        Assert.Equal(System.Net.HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+    
+
+    [Fact]
+    public async Task Search_RequiresAuth()
+    {
+        await SeedGuestsAsync();
+        var resp = await Client.GetAsync("/api/guests/search?query=Raj");
+        Assert.Equal(System.Net.HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+}
+
+

--- a/Atlas.Api.Tests/ReportsControllerTests.cs
+++ b/Atlas.Api.Tests/ReportsControllerTests.cs
@@ -55,6 +55,7 @@ public class ReportsControllerTests
             .UseInMemoryDatabase(nameof(GetCalendarEarnings_SpansMultipleDays))
             .Options;
         using var context = new AppDbContext(options);
+        context.Guests.Add(new Guest { Id = 1, Name = "Unknown", Phone = "1", Email = "u@e.com" });
         context.Bookings.Add(new Booking
         {
             ListingId = 1,
@@ -89,6 +90,7 @@ public class ReportsControllerTests
             .UseInMemoryDatabase(nameof(GetCalendarEarnings_MultipleEntriesSameSource))
             .Options;
         using var context = new AppDbContext(options);
+        context.Guests.Add(new Guest { Id = 1, Name = "Unknown", Phone = "1", Email = "u@e.com" });
         context.Bookings.AddRange(
             new Booking
             {
@@ -137,6 +139,7 @@ public class ReportsControllerTests
             .UseInMemoryDatabase(nameof(GetCalendarEarnings_ExcludesOutsideCalendarRange))
             .Options;
         using var context = new AppDbContext(options);
+        context.Guests.Add(new Guest { Id = 1, Name = "Unknown", Phone = "1", Email = "u@e.com" });
         context.Bookings.AddRange(
             new Booking
             {
@@ -192,6 +195,7 @@ public class ReportsControllerTests
             .UseInMemoryDatabase(nameof(GetCalendarEarnings_PreservesCheckinAcrossMonths))
             .Options;
         using var context = new AppDbContext(options);
+        context.Guests.Add(new Guest { Id = 1, Name = "Unknown", Phone = "1", Email = "u@e.com" });
         context.Bookings.Add(new Booking
         {
             ListingId = 1,
@@ -222,6 +226,7 @@ public class ReportsControllerTests
             .UseInMemoryDatabase(nameof(GetBankAccountEarnings_IncludesValidBookings))
             .Options;
         using var context = new AppDbContext(options);
+        context.Guests.Add(new Guest { Id = 1, Name = "Unknown", Phone = "1", Email = "u@e.com" });
         var account = new BankAccount { Id = 1, BankName = "Bank", AccountNumber = "0000861", IFSC = "IFSC", AccountType = "Savings" };
         context.BankAccounts.Add(account);
         context.Bookings.Add(new Booking
@@ -254,6 +259,7 @@ public class ReportsControllerTests
             .UseInMemoryDatabase(nameof(GetBankAccountEarnings_ExcludesOutsideRange))
             .Options;
         using var context = new AppDbContext(options);
+        context.Guests.Add(new Guest { Id = 1, Name = "Unknown", Phone = "1", Email = "u@e.com" });
         context.BankAccounts.Add(new BankAccount { Id = 1, BankName = "Bank", AccountNumber = "123456", IFSC = "I", AccountType = "S" });
         context.Bookings.Add(new Booking
         {
@@ -284,6 +290,7 @@ public class ReportsControllerTests
             .UseInMemoryDatabase(nameof(GetBankAccountEarnings_ReturnsZero_WhenAccountHasNoBookings))
             .Options;
         using var context = new AppDbContext(options);
+        context.Guests.Add(new Guest { Id = 1, Name = "Unknown", Phone = "1", Email = "u@e.com" });
         context.BankAccounts.Add(new BankAccount { Id = 1, BankName = "Bank", AccountNumber = "123456", IFSC = "I", AccountType = "S" });
         await context.SaveChangesAsync();
 
@@ -302,6 +309,7 @@ public class ReportsControllerTests
             .UseInMemoryDatabase(nameof(GetBankAccountEarnings_ReturnsEmpty_WhenNoBookings))
             .Options;
         using var context = new AppDbContext(options);
+        context.Guests.Add(new Guest { Id = 1, Name = "Unknown", Phone = "1", Email = "u@e.com" });
         var controller = new ReportsController(context, NullLogger<ReportsController>.Instance);
         var result = await controller.GetBankAccountEarnings();
         var ok = Assert.IsType<OkObjectResult>(result.Result);
@@ -316,6 +324,7 @@ public class ReportsControllerTests
             .UseInMemoryDatabase(nameof(GetBankAccountEarnings_AggregatesByAccount))
             .Options;
         using var context = new AppDbContext(options);
+        context.Guests.Add(new Guest { Id = 1, Name = "Unknown", Phone = "1", Email = "u@e.com" });
         context.BankAccounts.Add(new BankAccount { Id = 1, BankName = "Bank", AccountNumber = "99993290", IFSC = "I", AccountType = "S" });
         context.Bookings.AddRange(
             new Booking

--- a/Atlas.Api.Tests/SearchGuestsQueryHandlerTests.cs
+++ b/Atlas.Api.Tests/SearchGuestsQueryHandlerTests.cs
@@ -1,0 +1,88 @@
+using Application.Guests.Queries.SearchGuests;
+using Atlas.Api.Data;
+using Atlas.Api.Models;
+using Infrastructure.Phone;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Atlas.Api.Tests;
+
+public class SearchGuestsQueryHandlerTests
+{
+    private static (SearchGuestsQueryHandler handler, AppDbContext ctx) GetHandler(string name)
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(name)
+            .Options;
+        var ctx = new AppDbContext(options);
+        var handler = new SearchGuestsQueryHandler(ctx, new PhoneNormalizer(), new LoggerFactory().CreateLogger<SearchGuestsQueryHandler>());
+        return (handler, ctx);
+    }
+
+    [Fact]
+    public async Task Handle_FindsByPhone()
+    {
+        var (handler, ctx) = GetHandler(nameof(Handle_FindsByPhone));
+        var guest = new Guest { Name = "Raj", Phone = "990198734", Email = "raj@example.com" };
+        guest.NameSearch = guest.Name.ToLowerInvariant();
+        guest.PhoneE164 = new PhoneNormalizer().Normalize(guest.Phone);
+        ctx.Guests.Add(guest);
+        ctx.SaveChanges();
+        var result = await handler.Handle(new SearchGuestsRequest("990198734"), CancellationToken.None);
+        Assert.Single(result.Items);
+        Assert.Equal(guest.Id, result.Items[0].Id);
+    }
+
+    [Fact]
+    public async Task Handle_FindsByEmail()
+    {
+        var (handler, ctx) = GetHandler(nameof(Handle_FindsByEmail));
+        var guest = new Guest { Name = "Raj", Phone = "1", Email = "raj@example.com" };
+        guest.NameSearch = guest.Name.ToLowerInvariant();
+        guest.PhoneE164 = new PhoneNormalizer().Normalize(guest.Phone);
+        ctx.Guests.Add(guest);
+        ctx.SaveChanges();
+        var result = await handler.Handle(new SearchGuestsRequest("raj@example.com"), CancellationToken.None);
+        Assert.Single(result.Items);
+    }
+
+    [Fact]
+    public async Task Handle_FindsByNamePrefix()
+    {
+        var (handler, ctx) = GetHandler(nameof(Handle_FindsByNamePrefix));
+        var guest = new Guest { Name = "Rajesh", Phone = "1", Email = "r@example.com" };
+        guest.NameSearch = guest.Name.ToLowerInvariant();
+        ctx.Guests.Add(guest);
+        ctx.SaveChanges();
+        var result = await handler.Handle(new SearchGuestsRequest("ra"), CancellationToken.None);
+        Assert.Single(result.Items);
+    }
+
+    [Fact]
+    public async Task Handle_FindsByNameContains()
+    {
+        var (handler, ctx) = GetHandler(nameof(Handle_FindsByNameContains));
+        var guest = new Guest { Name = "Kiran Raj", Phone = "1", Email = "k@example.com" };
+        guest.NameSearch = guest.Name.ToLowerInvariant();
+        ctx.Guests.Add(guest);
+        ctx.SaveChanges();
+        var result = await handler.Handle(new SearchGuestsRequest("raj"), CancellationToken.None);
+        Assert.Single(result.Items);
+    }
+
+    [Fact]
+    public async Task Handle_PagingWorks()
+    {
+        var (handler, ctx) = GetHandler(nameof(Handle_PagingWorks));
+        for (int i = 0; i < 15; i++)
+        {
+            var g = new Guest { Name = $"Raj{i}", Phone = $"{i}", Email = $"r{i}@e.com" };
+            g.NameSearch = g.Name.ToLowerInvariant();
+            ctx.Guests.Add(g);
+        }
+        ctx.SaveChanges();
+        var result = await handler.Handle(new SearchGuestsRequest("raj", Page:2, PageSize:5), CancellationToken.None);
+        Assert.Equal(2, result.Page);
+        Assert.Equal(5, result.Items.Count);
+    }
+}

--- a/Atlas.Api/Atlas.Api.csproj
+++ b/Atlas.Api/Atlas.Api.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="libphonenumber-csharp" Version="8.13.31" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.5">
@@ -21,4 +22,8 @@
     <Folder Include="Migrations\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="..\Application\**\*.cs" Link="Application\%(RecursiveDir)%(Filename)%(Extension)" />
+    <Compile Include="..\Infrastructure\**\*.cs" Link="Infrastructure\%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
 </Project>

--- a/Atlas.Api/Controllers/GuestsController.cs
+++ b/Atlas.Api/Controllers/GuestsController.cs
@@ -1,8 +1,11 @@
-
+using Application.Guests.Queries.SearchGuests;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.EntityFrameworkCore;
 using Atlas.Api.Data;
 using Atlas.Api.Models;
+using Infrastructure.Phone;
 
 namespace Atlas.Api.Controllers
 {
@@ -12,10 +15,14 @@ namespace Atlas.Api.Controllers
     public class GuestsController : ControllerBase
     {
         private readonly AppDbContext _context;
+        private readonly SearchGuestsQueryHandler _handler;
+        private readonly PhoneNormalizer _phoneNormalizer;
 
-        public GuestsController(AppDbContext context)
+        public GuestsController(AppDbContext context, SearchGuestsQueryHandler handler, PhoneNormalizer phoneNormalizer)
         {
             _context = context;
+            _handler = handler;
+            _phoneNormalizer = phoneNormalizer;
         }
 
         [HttpGet]
@@ -31,6 +38,23 @@ namespace Atlas.Api.Controllers
             return item == null ? NotFound() : item;
         }
 
+        [Authorize]
+        [EnableRateLimiting("SearchGuestsLimit")]
+        [HttpGet("search")]
+        public async Task<ActionResult<SearchGuestsResponse>> Search([FromQuery] string query, [FromQuery] int page = 1, [FromQuery] int pageSize = 10, [FromQuery] string? fields = null, CancellationToken cancellationToken = default)
+        {
+            var trimmed = (query ?? string.Empty).Trim();
+            var digitsOnly = trimmed.All(char.IsDigit);
+            if (!digitsOnly && !trimmed.Contains('@') && trimmed.Length < 2)
+            {
+                return BadRequest("Query must be at least 2 characters.");
+            }
+            pageSize = Math.Clamp(pageSize, 5, 25);
+            var request = new SearchGuestsRequest(trimmed, page, pageSize, fields);
+            var result = await _handler.Handle(request, cancellationToken);
+            return Ok(result);
+        }
+
         [HttpPost]
         public async Task<ActionResult<Guest>> Create(Guest item)
         {
@@ -38,6 +62,8 @@ namespace Atlas.Api.Controllers
             {
                 item.IdProofUrl = "N/A";
             }
+            item.NameSearch = item.Name.ToLowerInvariant();
+            item.PhoneE164 = _phoneNormalizer.Normalize(item.Phone);
 
             _context.Guests.Add(item);
             await _context.SaveChangesAsync();
@@ -48,6 +74,8 @@ namespace Atlas.Api.Controllers
         public async Task<IActionResult> Update(int id, Guest item)
         {
             if (id != item.Id) return BadRequest();
+            item.NameSearch = item.Name.ToLowerInvariant();
+            item.PhoneE164 = _phoneNormalizer.Normalize(item.Phone);
             _context.Entry(item).State = EntityState.Modified;
             await _context.SaveChangesAsync();
             return NoContent();

--- a/Atlas.Api/Data/AppDbContext.cs
+++ b/Atlas.Api/Data/AppDbContext.cs
@@ -13,6 +13,7 @@ namespace Atlas.Api.Data
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             base.OnModelCreating(modelBuilder);
+            modelBuilder.ApplyConfigurationsFromAssembly(typeof(AppDbContext).Assembly);
 
             // All environments use DeleteBehavior.Restrict to avoid accidental
             // cascading deletes. Integration tests explicitly clean up related

--- a/Atlas.Api/Models/Guest.cs
+++ b/Atlas.Api/Models/Guest.cs
@@ -1,4 +1,3 @@
-
 namespace Atlas.Api.Models
 {
     public class Guest
@@ -6,7 +5,9 @@ namespace Atlas.Api.Models
         public int Id { get; set; }
         public required string Name { get; set; }
         public required string Phone { get; set; }
+        public string? PhoneE164 { get; set; }
         public required string Email { get; set; }
+        public string NameSearch { get; set; } = string.Empty;
         public string? IdProofUrl { get; set; }
     }
 }

--- a/Infrastructure/Persistence/Configurations/GuestConfiguration.cs
+++ b/Infrastructure/Persistence/Configurations/GuestConfiguration.cs
@@ -1,0 +1,15 @@
+using Atlas.Api.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Infrastructure.Persistence.Configurations;
+
+public class GuestConfiguration : IEntityTypeConfiguration<Guest>
+{
+    public void Configure(EntityTypeBuilder<Guest> builder)
+    {
+        builder.HasIndex(g => g.PhoneE164);
+        builder.HasIndex(g => g.Email);
+        builder.HasIndex(g => g.NameSearch);
+    }
+}

--- a/Infrastructure/Phone/PhoneNormalizer.cs
+++ b/Infrastructure/Phone/PhoneNormalizer.cs
@@ -1,0 +1,22 @@
+using System.Linq;
+using PhoneNumbers;
+
+namespace Infrastructure.Phone;
+
+public class PhoneNormalizer
+{
+    private readonly PhoneNumberUtil _util = PhoneNumberUtil.GetInstance();
+
+    public string Normalize(string input)
+    {
+        try
+        {
+            var number = _util.Parse(input, "IN");
+            return _util.Format(number, PhoneNumberFormat.E164);
+        }
+        catch
+        {
+            return new string(input.Where(char.IsDigit).ToArray());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add DTOs, handler, and controller endpoint for guest search
- normalize phones, add indexes, and wire up rate limiting
- include phone normalization utility and tests

## Testing
- `dotnet test Atlas.Api.Tests/Atlas.Api.Tests.csproj`
- `dotnet test Atlas.Api.IntegrationTests/Atlas.Api.IntegrationTests.csproj` *(fails: SQL Server LocalDB unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a1458b14832ba365d70749462010